### PR TITLE
[FEAT] 프로젝트 목록/챗봇 핵심 UI 구현 및 MSW 개발 환경 세팅

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -33,6 +33,7 @@
         "eslint-config-prettier": "^9.1.0",
         "eslint-plugin-react-hooks": "^5.0.0",
         "eslint-plugin-react-refresh": "^0.4.14",
+        "msw": "^2.13.3",
         "postcss": "^8.4.49",
         "prettier": "^3.4.2",
         "tailwindcss": "^3.4.16",
@@ -1061,6 +1062,94 @@
         "url": "https://github.com/sponsors/nzakas"
       }
     },
+    "node_modules/@inquirer/ansi": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/ansi/-/ansi-1.0.2.tgz",
+      "integrity": "sha512-S8qNSZiYzFd0wAcyG5AXCvUHC5Sr7xpZ9wZ2py9XR88jUz8wooStVx5M6dRzczbBWjic9NP7+rY0Xi7qqK/aMQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/confirm": {
+      "version": "5.1.21",
+      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-5.1.21.tgz",
+      "integrity": "sha512-KR8edRkIsUayMXV+o3Gv+q4jlhENF9nMYUZs9PA2HzrXeHI8M5uDag70U7RJn9yyiMZSbtF5/UexBtAVtZGSbQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^10.3.2",
+        "@inquirer/type": "^3.0.10"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/core": {
+      "version": "10.3.2",
+      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-10.3.2.tgz",
+      "integrity": "sha512-43RTuEbfP8MbKzedNqBrlhhNKVwoK//vUFNW3Q3vZ88BLcrs4kYpGg+B2mm5p2K/HfygoCxuKwJJiv8PbGmE0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/ansi": "^1.0.2",
+        "@inquirer/figures": "^1.0.15",
+        "@inquirer/type": "^3.0.10",
+        "cli-width": "^4.1.0",
+        "mute-stream": "^2.0.0",
+        "signal-exit": "^4.1.0",
+        "wrap-ansi": "^6.2.0",
+        "yoctocolors-cjs": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/figures": {
+      "version": "1.0.15",
+      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.15.tgz",
+      "integrity": "sha512-t2IEY+unGHOzAaVM5Xx6DEWKeXlDDcNPeDyUpsRc6CUhBfU3VQOEl+Vssh7VNp1dR8MdUJBWhuObjXCsVpjN5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/type": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-3.0.10.tgz",
+      "integrity": "sha512-BvziSRxfz5Ov8ch0z/n3oijRSEcEsHnhggm4xFZe93DHcUCTlutlq9Ox4SVENAfcRD22UQq7T/atg9Wr3k09eA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
@@ -1111,6 +1200,24 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@mswjs/interceptors": {
+      "version": "0.41.3",
+      "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.41.3.tgz",
+      "integrity": "sha512-cXu86tF4VQVfwz8W1SPbhoRyHJkti6mjH/XJIxp40jhO4j2k1m4KYrEykxqWPkFF3vrK4rgQppBh//AwyGSXPA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@open-draft/deferred-promise": "^2.2.0",
+        "@open-draft/logger": "^0.3.0",
+        "@open-draft/until": "^2.0.0",
+        "is-node-process": "^1.2.0",
+        "outvariant": "^1.4.3",
+        "strict-event-emitter": "^0.5.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -1148,6 +1255,31 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/@open-draft/deferred-promise": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/deferred-promise/-/deferred-promise-2.2.0.tgz",
+      "integrity": "sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@open-draft/logger": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/logger/-/logger-0.3.0.tgz",
+      "integrity": "sha512-X2g45fzhxH238HKO4xbSr7+wBS8Fvw6ixhTDuvLd5mqh6bJJCFAPwU9mPDxbcrRtfxv4u5IHCEH77BmxvXmmxQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-node-process": "^1.2.0",
+        "outvariant": "^1.4.0"
+      }
+    },
+    "node_modules/@open-draft/until": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@open-draft/until/-/until-2.1.0.tgz",
+      "integrity": "sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@remix-run/router": {
       "version": "1.23.2",
@@ -1638,6 +1770,13 @@
         "@types/react": "^18.0.0"
       }
     },
+    "node_modules/@types/statuses": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@types/statuses/-/statuses-2.0.6.tgz",
+      "integrity": "sha512-xMAgYwceFhRA2zY+XbEA7mxYbA093wdiW8Vu6gZPGWy9cmOyU9XesH1tNcEWsKFd5Vzrqx5T3D38PWx1FIIXkA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.57.2",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.57.2.tgz",
@@ -1930,6 +2069,16 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/ansi-styles": {
@@ -2251,6 +2400,49 @@
         "node": ">= 6"
       }
     },
+    "node_modules/cli-width": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-4.1.0.tgz",
+      "integrity": "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/cliui/node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -2306,6 +2498,20 @@
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -2420,6 +2626,13 @@
       "integrity": "sha512-hLxLdIJDf8zIzKoH2TPCs+Botc+wUmj9sp4jVMwklY/sKleM8xxxOExRX3Gxj73nCXmJe3anhG7SvsDDPDvmuQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/es-define-property": {
       "version": "1.0.1",
@@ -3009,6 +3222,16 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
     "node_modules/get-intrinsic": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
@@ -3084,6 +3307,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/graphql": {
+      "version": "16.13.2",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.13.2.tgz",
+      "integrity": "sha512-5bJ+nf/UCpAjHM8i06fl7eLyVC9iuNAjm9qzkiu2ZGhM0VscSvS6WDPfAwkdkBuoXGM9FJSbKl6wylMwP9Ktig==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
+      }
+    },
     "node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -3132,6 +3365,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/headers-polyfill": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/headers-polyfill/-/headers-polyfill-4.0.3.tgz",
+      "integrity": "sha512-IScLbePpkvO846sIwOtOTDjutRMWdXdJmXdMvk6gCBHxFO8d+QKOQedyZSxFTTFYRSmlgSTDtXqqq4pcenBXLQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ignore": {
       "version": "7.0.5",
@@ -3209,6 +3449,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/is-glob": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
@@ -3221,6 +3471,13 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/is-node-process": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-node-process/-/is-node-process-1.2.0.tgz",
+      "integrity": "sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/is-number": {
       "version": "7.0.0",
@@ -3490,6 +3747,61 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/msw": {
+      "version": "2.13.3",
+      "resolved": "https://registry.npmjs.org/msw/-/msw-2.13.3.tgz",
+      "integrity": "sha512-/F49bxavkNGfreMlrKmTxZs6YorjfMbbDLd89Q3pWi+cXGtQQNXXaHt4MkXN7li91xnQJ24HWXqW9QDm5id33w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/confirm": "^5.0.0",
+        "@mswjs/interceptors": "^0.41.2",
+        "@open-draft/deferred-promise": "^2.2.0",
+        "@types/statuses": "^2.0.6",
+        "cookie": "^1.0.2",
+        "graphql": "^16.12.0",
+        "headers-polyfill": "^4.0.2",
+        "is-node-process": "^1.2.0",
+        "outvariant": "^1.4.3",
+        "path-to-regexp": "^6.3.0",
+        "picocolors": "^1.1.1",
+        "rettime": "^0.11.7",
+        "statuses": "^2.0.2",
+        "strict-event-emitter": "^0.5.1",
+        "tough-cookie": "^6.0.0",
+        "type-fest": "^5.2.0",
+        "until-async": "^3.0.2",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "msw": "cli/index.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mswjs"
+      },
+      "peerDependencies": {
+        "typescript": ">= 4.8.x"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/mute-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-2.0.0.tgz",
+      "integrity": "sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
     "node_modules/mz": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
@@ -3582,6 +3894,13 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/outvariant": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/outvariant/-/outvariant-1.4.3.tgz",
+      "integrity": "sha512-+Sl2UErvtsoajRDKCE5/dBz4DIvHXQQnAxtQTF04OJxY0+DyZXSo5P5Bb7XYWOh81syohlYL24hbDwxedPUJCA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/p-limit": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
@@ -3651,6 +3970,13 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/path-to-regexp": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
+      "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -4060,6 +4386,16 @@
         "node": ">=8.10.0"
       }
     },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/resolve": {
       "version": "1.22.11",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.11.tgz",
@@ -4090,6 +4426,13 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/rettime": {
+      "version": "0.11.7",
+      "resolved": "https://registry.npmjs.org/rettime/-/rettime-0.11.7.tgz",
+      "integrity": "sha512-DoAm1WjR1eH7z8sHPtvvUMIZh4/CSKkGCz6CxPqOrEAnOGtOuHSnSE9OC+razqxKuf4ub7pAYyl/vZV0vGs5tg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/reusify": {
       "version": "1.1.0",
@@ -4216,6 +4559,19 @@
         "node": ">=8"
       }
     },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -4224,6 +4580,51 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/strict-event-emitter": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/strict-event-emitter/-/strict-event-emitter-0.5.1.tgz",
+      "integrity": "sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/strip-json-comments": {
@@ -4286,6 +4687,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/tagged-tag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/tagged-tag/-/tagged-tag-1.0.0.tgz",
+      "integrity": "sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/tailwindcss": {
@@ -4397,6 +4811,26 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/tldts": {
+      "version": "7.0.28",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.28.tgz",
+      "integrity": "sha512-+Zg3vWhRUv8B1maGSTFdev9mjoo8Etn2Ayfs4cnjlD3CsGkxXX4QyW3j2WJ0wdjYcYmy7Lx2RDsZMhgCWafKIw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.0.28"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.0.28",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.28.tgz",
+      "integrity": "sha512-7W5Efjhsc3chVdFhqtaU0KtK32J37Zcr9RKtID54nG+tIpcY79CQK/veYPODxtD/LJ4Lue66jvrQzIX2Z2/pUQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -4408,6 +4842,19 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
+      "integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/ts-api-utils": {
@@ -4449,6 +4896,22 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/type-fest": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-5.5.0.tgz",
+      "integrity": "sha512-PlBfpQwiUvGViBNX84Yxwjsdhd1TUlXr6zjX7eoirtCPIr08NAmxwa+fcYBTeRQxHo9YC9wwF3m9i700sHma8g==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "dependencies": {
+        "tagged-tag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/typescript": {
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
@@ -4469,6 +4932,16 @@
       "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/until-async": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/until-async/-/until-async-3.0.2.tgz",
+      "integrity": "sha512-IiSk4HlzAMqTUseHHe3VhIGyuFmN90zMTpD3Z3y8jeQbzLIq500MVM7Jq2vUAnTKAFPJrqwkzr6PoTcPhGcOiw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/kettanaito"
+      }
     },
     "node_modules/update-browserslist-db": {
       "version": "1.2.3",
@@ -4650,12 +5123,66 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/wrap-ansi": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/yallist": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",
@@ -4665,6 +5192,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/yoctocolors-cjs": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/yoctocolors-cjs/-/yoctocolors-cjs-2.1.3.tgz",
+      "integrity": "sha512-U/PBtDf35ff0D8X8D0jfdzHYEPFxAI7jJlxZXwCSez5M3190m+QobIfh+sWDWSHMCWWJN2AWamkegn6vr6YBTw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -36,10 +36,16 @@
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-react-hooks": "^5.0.0",
     "eslint-plugin-react-refresh": "^0.4.14",
+    "msw": "^2.13.3",
     "postcss": "^8.4.49",
     "prettier": "^3.4.2",
     "tailwindcss": "^3.4.16",
     "typescript": "^5.7.2",
     "vite": "^6.0.5"
+  },
+  "msw": {
+    "workerDirectory": [
+      "public"
+    ]
   }
 }

--- a/frontend/public/mockServiceWorker.js
+++ b/frontend/public/mockServiceWorker.js
@@ -1,0 +1,349 @@
+/* eslint-disable */
+/* tslint:disable */
+
+/**
+ * Mock Service Worker.
+ * @see https://github.com/mswjs/msw
+ * - Please do NOT modify this file.
+ */
+
+const PACKAGE_VERSION = '2.13.3'
+const INTEGRITY_CHECKSUM = '4db4a41e972cec1b64cc569c66952d82'
+const IS_MOCKED_RESPONSE = Symbol('isMockedResponse')
+const activeClientIds = new Set()
+
+addEventListener('install', function () {
+  self.skipWaiting()
+})
+
+addEventListener('activate', function (event) {
+  event.waitUntil(self.clients.claim())
+})
+
+addEventListener('message', async function (event) {
+  const clientId = Reflect.get(event.source || {}, 'id')
+
+  if (!clientId || !self.clients) {
+    return
+  }
+
+  const client = await self.clients.get(clientId)
+
+  if (!client) {
+    return
+  }
+
+  const allClients = await self.clients.matchAll({
+    type: 'window',
+  })
+
+  switch (event.data) {
+    case 'KEEPALIVE_REQUEST': {
+      sendToClient(client, {
+        type: 'KEEPALIVE_RESPONSE',
+      })
+      break
+    }
+
+    case 'INTEGRITY_CHECK_REQUEST': {
+      sendToClient(client, {
+        type: 'INTEGRITY_CHECK_RESPONSE',
+        payload: {
+          packageVersion: PACKAGE_VERSION,
+          checksum: INTEGRITY_CHECKSUM,
+        },
+      })
+      break
+    }
+
+    case 'MOCK_ACTIVATE': {
+      activeClientIds.add(clientId)
+
+      sendToClient(client, {
+        type: 'MOCKING_ENABLED',
+        payload: {
+          client: {
+            id: client.id,
+            frameType: client.frameType,
+          },
+        },
+      })
+      break
+    }
+
+    case 'CLIENT_CLOSED': {
+      activeClientIds.delete(clientId)
+
+      const remainingClients = allClients.filter((client) => {
+        return client.id !== clientId
+      })
+
+      // Unregister itself when there are no more clients
+      if (remainingClients.length === 0) {
+        self.registration.unregister()
+      }
+
+      break
+    }
+  }
+})
+
+addEventListener('fetch', function (event) {
+  const requestInterceptedAt = Date.now()
+
+  // Bypass navigation requests.
+  if (event.request.mode === 'navigate') {
+    return
+  }
+
+  // Opening the DevTools triggers the "only-if-cached" request
+  // that cannot be handled by the worker. Bypass such requests.
+  if (
+    event.request.cache === 'only-if-cached' &&
+    event.request.mode !== 'same-origin'
+  ) {
+    return
+  }
+
+  // Bypass all requests when there are no active clients.
+  // Prevents the self-unregistered worked from handling requests
+  // after it's been terminated (still remains active until the next reload).
+  if (activeClientIds.size === 0) {
+    return
+  }
+
+  const requestId = crypto.randomUUID()
+  event.respondWith(handleRequest(event, requestId, requestInterceptedAt))
+})
+
+/**
+ * @param {FetchEvent} event
+ * @param {string} requestId
+ * @param {number} requestInterceptedAt
+ */
+async function handleRequest(event, requestId, requestInterceptedAt) {
+  const client = await resolveMainClient(event)
+  const requestCloneForEvents = event.request.clone()
+  const response = await getResponse(
+    event,
+    client,
+    requestId,
+    requestInterceptedAt,
+  )
+
+  // Send back the response clone for the "response:*" life-cycle events.
+  // Ensure MSW is active and ready to handle the message, otherwise
+  // this message will pend indefinitely.
+  if (client && activeClientIds.has(client.id)) {
+    const serializedRequest = await serializeRequest(requestCloneForEvents)
+
+    // Clone the response so both the client and the library could consume it.
+    const responseClone = response.clone()
+
+    sendToClient(
+      client,
+      {
+        type: 'RESPONSE',
+        payload: {
+          isMockedResponse: IS_MOCKED_RESPONSE in response,
+          request: {
+            id: requestId,
+            ...serializedRequest,
+          },
+          response: {
+            type: responseClone.type,
+            status: responseClone.status,
+            statusText: responseClone.statusText,
+            headers: Object.fromEntries(responseClone.headers.entries()),
+            body: responseClone.body,
+          },
+        },
+      },
+      responseClone.body ? [serializedRequest.body, responseClone.body] : [],
+    )
+  }
+
+  return response
+}
+
+/**
+ * Resolve the main client for the given event.
+ * Client that issues a request doesn't necessarily equal the client
+ * that registered the worker. It's with the latter the worker should
+ * communicate with during the response resolving phase.
+ * @param {FetchEvent} event
+ * @returns {Promise<Client | undefined>}
+ */
+async function resolveMainClient(event) {
+  const client = await self.clients.get(event.clientId)
+
+  if (activeClientIds.has(event.clientId)) {
+    return client
+  }
+
+  if (client?.frameType === 'top-level') {
+    return client
+  }
+
+  const allClients = await self.clients.matchAll({
+    type: 'window',
+  })
+
+  return allClients
+    .filter((client) => {
+      // Get only those clients that are currently visible.
+      return client.visibilityState === 'visible'
+    })
+    .find((client) => {
+      // Find the client ID that's recorded in the
+      // set of clients that have registered the worker.
+      return activeClientIds.has(client.id)
+    })
+}
+
+/**
+ * @param {FetchEvent} event
+ * @param {Client | undefined} client
+ * @param {string} requestId
+ * @param {number} requestInterceptedAt
+ * @returns {Promise<Response>}
+ */
+async function getResponse(event, client, requestId, requestInterceptedAt) {
+  // Clone the request because it might've been already used
+  // (i.e. its body has been read and sent to the client).
+  const requestClone = event.request.clone()
+
+  function passthrough() {
+    // Cast the request headers to a new Headers instance
+    // so the headers can be manipulated with.
+    const headers = new Headers(requestClone.headers)
+
+    // Remove the "accept" header value that marked this request as passthrough.
+    // This prevents request alteration and also keeps it compliant with the
+    // user-defined CORS policies.
+    const acceptHeader = headers.get('accept')
+    if (acceptHeader) {
+      const values = acceptHeader.split(',').map((value) => value.trim())
+      const filteredValues = values.filter(
+        (value) => value !== 'msw/passthrough',
+      )
+
+      if (filteredValues.length > 0) {
+        headers.set('accept', filteredValues.join(', '))
+      } else {
+        headers.delete('accept')
+      }
+    }
+
+    return fetch(requestClone, { headers })
+  }
+
+  // Bypass mocking when the client is not active.
+  if (!client) {
+    return passthrough()
+  }
+
+  // Bypass initial page load requests (i.e. static assets).
+  // The absence of the immediate/parent client in the map of the active clients
+  // means that MSW hasn't dispatched the "MOCK_ACTIVATE" event yet
+  // and is not ready to handle requests.
+  if (!activeClientIds.has(client.id)) {
+    return passthrough()
+  }
+
+  // Notify the client that a request has been intercepted.
+  const serializedRequest = await serializeRequest(event.request)
+  const clientMessage = await sendToClient(
+    client,
+    {
+      type: 'REQUEST',
+      payload: {
+        id: requestId,
+        interceptedAt: requestInterceptedAt,
+        ...serializedRequest,
+      },
+    },
+    [serializedRequest.body],
+  )
+
+  switch (clientMessage.type) {
+    case 'MOCK_RESPONSE': {
+      return respondWithMock(clientMessage.data)
+    }
+
+    case 'PASSTHROUGH': {
+      return passthrough()
+    }
+  }
+
+  return passthrough()
+}
+
+/**
+ * @param {Client} client
+ * @param {any} message
+ * @param {Array<Transferable>} transferrables
+ * @returns {Promise<any>}
+ */
+function sendToClient(client, message, transferrables = []) {
+  return new Promise((resolve, reject) => {
+    const channel = new MessageChannel()
+
+    channel.port1.onmessage = (event) => {
+      if (event.data && event.data.error) {
+        return reject(event.data.error)
+      }
+
+      resolve(event.data)
+    }
+
+    client.postMessage(message, [
+      channel.port2,
+      ...transferrables.filter(Boolean),
+    ])
+  })
+}
+
+/**
+ * @param {Response} response
+ * @returns {Response}
+ */
+function respondWithMock(response) {
+  // Setting response status code to 0 is a no-op.
+  // However, when responding with a "Response.error()", the produced Response
+  // instance will have status code set to 0. Since it's not possible to create
+  // a Response instance with status code 0, handle that use-case separately.
+  if (response.status === 0) {
+    return Response.error()
+  }
+
+  const mockedResponse = new Response(response.body, response)
+
+  Reflect.defineProperty(mockedResponse, IS_MOCKED_RESPONSE, {
+    value: true,
+    enumerable: true,
+  })
+
+  return mockedResponse
+}
+
+/**
+ * @param {Request} request
+ */
+async function serializeRequest(request) {
+  return {
+    url: request.url,
+    mode: request.mode,
+    method: request.method,
+    headers: Object.fromEntries(request.headers.entries()),
+    cache: request.cache,
+    credentials: request.credentials,
+    destination: request.destination,
+    integrity: request.integrity,
+    redirect: request.redirect,
+    referrer: request.referrer,
+    referrerPolicy: request.referrerPolicy,
+    body: await request.arrayBuffer(),
+    keepalive: request.keepalive,
+  }
+}

--- a/frontend/src/api/search.ts
+++ b/frontend/src/api/search.ts
@@ -1,4 +1,5 @@
 import { api } from './axiosInstance'
+import axios from 'axios'
 import type { NaturalSearchResult } from '@/types/chat'
 import type { PagedResponse, ProjectSummary } from '@/types/project'
 
@@ -16,3 +17,15 @@ export const searchNatural = (query: string, sessionId?: string) =>
   api
     .post<NaturalSearchResult>('/api/search/natural', { query, sessionId })
     .then((r) => r.data)
+
+// Direct AI service call — used while backend is not yet implemented
+const aiApi = axios.create({
+  baseURL: import.meta.env.VITE_AI_SERVICE_URL ?? 'http://localhost:8000',
+  timeout: 30000,
+})
+
+export const searchNaturalDirect = (query: string, topK = 5) =>
+  aiApi
+    .post<NaturalSearchResult>('/search', { query, top_k: topK })
+    .then((r) => r.data)
+

--- a/frontend/src/components/project/ProjectCard.tsx
+++ b/frontend/src/components/project/ProjectCard.tsx
@@ -1,0 +1,67 @@
+import { Link } from 'react-router-dom'
+import type { ProjectSummary } from '@/types/project'
+import { ProjectStatusBadge } from './ProjectStatusBadge'
+
+interface ProjectCardProps {
+  project: ProjectSummary
+  /** AI 검색 결과에서 넘어온 추천 이유 (선택) */
+  matchReasons?: string[]
+  showStatus?: boolean
+}
+
+export function ProjectCard({ project, matchReasons, showStatus = false }: ProjectCardProps) {
+  return (
+    <Link
+      to={`/projects/${project.id}`}
+      className="flex flex-col gap-3 rounded-xl border border-gray-200 bg-white p-5 shadow-sm transition hover:shadow-md"
+    >
+      {/* 헤더 */}
+      <div className="flex items-start justify-between gap-2">
+        <h3 className="line-clamp-2 text-base font-semibold text-gray-900">
+          {project.title}
+        </h3>
+        {showStatus && <ProjectStatusBadge status={project.status} />}
+      </div>
+
+      {/* 한 줄 소개 */}
+      <p className="line-clamp-2 text-sm text-gray-500">{project.summary}</p>
+
+      {/* 기술 스택 태그 */}
+      {project.techStacks.length > 0 && (
+        <div className="flex flex-wrap gap-1.5">
+          {project.techStacks.slice(0, 5).map((stack) => (
+            <span
+              key={stack}
+              className="rounded-md bg-primary-50 px-2 py-0.5 text-xs text-primary-700"
+            >
+              {stack}
+            </span>
+          ))}
+          {project.techStacks.length > 5 && (
+            <span className="text-xs text-gray-400">+{project.techStacks.length - 5}</span>
+          )}
+        </div>
+      )}
+
+      {/* AI 추천 이유 */}
+      {matchReasons && matchReasons.length > 0 && (
+        <div className="rounded-md bg-blue-50 px-3 py-2 text-xs text-blue-700">
+          💡 {matchReasons.join(' · ')}
+        </div>
+      )}
+
+      {/* 하단 메타 */}
+      <div className="flex items-center gap-3 text-xs text-gray-400">
+        <span>{project.year}년 {project.semester}학기</span>
+        <span>·</span>
+        <span>{project.subjectName}</span>
+        {project.teamName && (
+          <>
+            <span>·</span>
+            <span>{project.teamName}</span>
+          </>
+        )}
+      </div>
+    </Link>
+  )
+}

--- a/frontend/src/components/project/ProjectStatusBadge.tsx
+++ b/frontend/src/components/project/ProjectStatusBadge.tsx
@@ -1,0 +1,23 @@
+import type { ProjectStatus } from '@/types/project'
+
+interface BadgeProps {
+  status: ProjectStatus
+}
+
+const statusConfig: Record<ProjectStatus, { label: string; className: string }> = {
+  PENDING_APPROVAL: { label: '승인 대기', className: 'bg-yellow-100 text-yellow-700' },
+  APPROVED:         { label: '승인',      className: 'bg-green-100 text-green-700' },
+  REJECTED:         { label: '반려',      className: 'bg-red-100 text-red-700' },
+  REVISION_REQUESTED: { label: '수정 요청', className: 'bg-orange-100 text-orange-700' },
+  PRIVATE:          { label: '비공개',    className: 'bg-gray-100 text-gray-600' },
+  DELETED:          { label: '삭제됨',    className: 'bg-gray-200 text-gray-500' },
+}
+
+export function ProjectStatusBadge({ status }: BadgeProps) {
+  const { label, className } = statusConfig[status]
+  return (
+    <span className={`inline-block rounded-full px-2.5 py-0.5 text-xs font-medium ${className}`}>
+      {label}
+    </span>
+  )
+}

--- a/frontend/src/components/search/FilterPanel.tsx
+++ b/frontend/src/components/search/FilterPanel.tsx
@@ -1,0 +1,122 @@
+import { useSearchStore } from '@/store/searchStore'
+import { Button } from '@/components/ui/Button'
+
+// Available filter options — will be replaced with API data when backend is ready
+const TECH_OPTIONS = ['React', 'Spring Boot', 'FastAPI', 'PostgreSQL', 'PyTorch', 'TypeScript', 'Python', 'Docker']
+const SEMESTER_OPTIONS: (1 | 2)[] = [1, 2]
+const CURRENT_YEAR = new Date().getFullYear()
+const YEAR_OPTIONS = Array.from({ length: 5 }, (_, i) => CURRENT_YEAR - i)
+
+export function FilterPanel() {
+  const { filters, setFilter, resetFilters } = useSearchStore()
+
+  const toggleArrayItem = <T,>(arr: T[], item: T): T[] =>
+    arr.includes(item) ? arr.filter((v) => v !== item) : [...arr, item]
+
+  const hasActiveFilter =
+    filters.years.length > 0 ||
+    filters.semester !== null ||
+    filters.techStacks.length > 0 ||
+    filters.isTeam !== null
+
+  return (
+    <aside className="w-56 shrink-0 space-y-5">
+      {/* 헤더 */}
+      <div className="flex items-center justify-between">
+        <span className="text-sm font-semibold text-gray-800">필터</span>
+        {hasActiveFilter && (
+          <button onClick={resetFilters} className="text-xs text-primary-600 hover:underline">
+            초기화
+          </button>
+        )}
+      </div>
+
+      {/* 연도 */}
+      <div>
+        <p className="mb-2 text-xs font-medium text-gray-500 uppercase tracking-wide">수행 연도</p>
+        <div className="flex flex-wrap gap-1.5">
+          {YEAR_OPTIONS.map((year) => (
+            <button
+              key={year}
+              onClick={() => setFilter('years', toggleArrayItem(filters.years, year))}
+              className={`rounded-md border px-2.5 py-1 text-xs transition ${
+                filters.years.includes(year)
+                  ? 'border-primary-500 bg-primary-50 text-primary-700'
+                  : 'border-gray-200 text-gray-600 hover:border-gray-300'
+              }`}
+            >
+              {year}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {/* 학기 */}
+      <div>
+        <p className="mb-2 text-xs font-medium text-gray-500 uppercase tracking-wide">학기</p>
+        <div className="flex gap-2">
+          {SEMESTER_OPTIONS.map((s) => (
+            <button
+              key={s}
+              onClick={() => setFilter('semester', filters.semester === s ? null : s)}
+              className={`flex-1 rounded-md border py-1 text-xs transition ${
+                filters.semester === s
+                  ? 'border-primary-500 bg-primary-50 text-primary-700'
+                  : 'border-gray-200 text-gray-600 hover:border-gray-300'
+              }`}
+            >
+              {s}학기
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {/* 기술 스택 */}
+      <div>
+        <p className="mb-2 text-xs font-medium text-gray-500 uppercase tracking-wide">기술 스택</p>
+        <div className="flex flex-wrap gap-1.5">
+          {TECH_OPTIONS.map((tech) => (
+            <button
+              key={tech}
+              onClick={() => setFilter('techStacks', toggleArrayItem(filters.techStacks, tech))}
+              className={`rounded-md border px-2.5 py-1 text-xs transition ${
+                filters.techStacks.includes(tech)
+                  ? 'border-primary-500 bg-primary-50 text-primary-700'
+                  : 'border-gray-200 text-gray-600 hover:border-gray-300'
+              }`}
+            >
+              {tech}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {/* 팀 프로젝트 여부 */}
+      <div>
+        <p className="mb-2 text-xs font-medium text-gray-500 uppercase tracking-wide">구분</p>
+        <div className="flex gap-2">
+          {[
+            { label: '팀', value: true },
+            { label: '개인', value: false },
+          ].map(({ label, value }) => (
+            <button
+              key={label}
+              onClick={() => setFilter('isTeam', filters.isTeam === value ? null : value)}
+              className={`flex-1 rounded-md border py-1 text-xs transition ${
+                filters.isTeam === value
+                  ? 'border-primary-500 bg-primary-50 text-primary-700'
+                  : 'border-gray-200 text-gray-600 hover:border-gray-300'
+              }`}
+            >
+              {label}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <Button variant="outline" size="sm" className="w-full" onClick={resetFilters}>
+        전체 초기화
+      </Button>
+    </aside>
+  )
+}

--- a/frontend/src/components/search/SearchBar.tsx
+++ b/frontend/src/components/search/SearchBar.tsx
@@ -1,0 +1,68 @@
+import { useRef } from 'react'
+import { Search } from 'lucide-react'
+import { useSearchStore } from '@/store/searchStore'
+
+interface SearchBarProps {
+  onSearch: () => void
+}
+
+export function SearchBar({ onSearch }: SearchBarProps) {
+  const { keyword, searchType, setKeyword, setSearchType } = useSearchStore()
+  const inputRef = useRef<HTMLInputElement>(null)
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    // Submit search on Enter key press
+    if (e.key === 'Enter') onSearch()
+  }
+
+  return (
+    <div className="flex flex-col gap-2">
+      {/* 검색 타입 탭 */}
+      <div className="flex gap-1 rounded-lg bg-gray-100 p-1 w-fit">
+        {(['keyword', 'natural'] as const).map((type) => (
+          <button
+            key={type}
+            onClick={() => setSearchType(type)}
+            className={`rounded-md px-3 py-1 text-sm font-medium transition ${
+              searchType === type
+                ? 'bg-white text-gray-900 shadow-sm'
+                : 'text-gray-500 hover:text-gray-700'
+            }`}
+          >
+            {type === 'keyword' ? '키워드 검색' : 'AI 자연어 검색'}
+          </button>
+        ))}
+      </div>
+
+      {/* 검색 입력창 */}
+      <div className="relative flex items-center">
+        <Search className="absolute left-3 h-4 w-4 text-gray-400 pointer-events-none" />
+        <input
+          ref={inputRef}
+          value={keyword}
+          onChange={(e) => setKeyword(e.target.value)}
+          onKeyDown={handleKeyDown}
+          placeholder={
+            searchType === 'keyword'
+              ? '프로젝트명, 기술 스택, 태그로 검색'
+              : '"React와 Spring을 사용한 웹 프로젝트 찾아줘"'
+          }
+          className="w-full rounded-xl border border-gray-300 py-3 pl-10 pr-24 text-sm outline-none focus:border-primary-500 focus:ring-2 focus:ring-primary-500"
+        />
+        <button
+          onClick={onSearch}
+          className="absolute right-2 rounded-lg bg-primary-600 px-4 py-1.5 text-sm font-medium text-white hover:bg-primary-700"
+        >
+          검색
+        </button>
+      </div>
+
+      {/* AI 검색 안내 */}
+      {searchType === 'natural' && (
+        <p className="text-xs text-gray-400">
+          자연어로 질문하면 AI가 관련 프로젝트를 찾고 설명해줍니다.
+        </p>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/components/ui/Button.tsx
+++ b/frontend/src/components/ui/Button.tsx
@@ -1,0 +1,35 @@
+import type { ButtonHTMLAttributes } from 'react'
+
+interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: 'primary' | 'outline' | 'ghost'
+  size?: 'sm' | 'md' | 'lg'
+}
+
+const variantClass = {
+  primary: 'bg-primary-600 text-white hover:bg-primary-700 disabled:opacity-50',
+  outline: 'border border-primary-600 text-primary-600 hover:bg-primary-50',
+  ghost: 'text-gray-600 hover:bg-gray-100',
+}
+
+const sizeClass = {
+  sm: 'px-3 py-1.5 text-sm',
+  md: 'px-4 py-2 text-sm',
+  lg: 'px-6 py-3 text-base',
+}
+
+export function Button({
+  variant = 'primary',
+  size = 'md',
+  className = '',
+  children,
+  ...props
+}: ButtonProps) {
+  return (
+    <button
+      className={`inline-flex items-center justify-center rounded-md font-medium transition-colors ${variantClass[variant]} ${sizeClass[size]} ${className}`}
+      {...props}
+    >
+      {children}
+    </button>
+  )
+}

--- a/frontend/src/components/ui/Input.tsx
+++ b/frontend/src/components/ui/Input.tsx
@@ -1,0 +1,23 @@
+import type { InputHTMLAttributes } from 'react'
+
+interface InputProps extends InputHTMLAttributes<HTMLInputElement> {
+  label?: string
+  error?: string
+}
+
+export function Input({ label, error, className = '', ...props }: InputProps) {
+  return (
+    <div className="w-full">
+      {label && (
+        <label className="mb-1 block text-sm font-medium text-gray-700">{label}</label>
+      )}
+      <input
+        className={`w-full rounded-md border px-3 py-2 text-sm outline-none transition focus:ring-2 focus:ring-primary-500 ${
+          error ? 'border-red-400 focus:ring-red-400' : 'border-gray-300'
+        } ${className}`}
+        {...props}
+      />
+      {error && <p className="mt-1 text-xs text-red-500">{error}</p>}
+    </div>
+  )
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -3,8 +3,18 @@ import ReactDOM from 'react-dom/client'
 import App from './App'
 import './index.css'
 
-ReactDOM.createRoot(document.getElementById('root')!).render(
-  <React.StrictMode>
-    <App />
-  </React.StrictMode>,
-)
+async function prepare() {
+  // Start MSW browser worker only when VITE_USE_MSW=true (local dev without backend)
+  if (import.meta.env.VITE_USE_MSW === 'true') {
+    const { worker } = await import('./mocks/browser')
+    await worker.start({ onUnhandledRequest: 'bypass' })
+  }
+}
+
+prepare().then(() => {
+  ReactDOM.createRoot(document.getElementById('root')!).render(
+    <React.StrictMode>
+      <App />
+    </React.StrictMode>,
+  )
+})

--- a/frontend/src/mocks/browser.ts
+++ b/frontend/src/mocks/browser.ts
@@ -1,0 +1,4 @@
+import { setupWorker } from 'msw/browser'
+import { handlers } from './handlers'
+
+export const worker = setupWorker(...handlers)

--- a/frontend/src/mocks/handlers.ts
+++ b/frontend/src/mocks/handlers.ts
@@ -1,0 +1,261 @@
+import { http, HttpResponse } from 'msw'
+import type { ProjectSummary, ProjectDetail } from '@/types/project'
+import type { PagedResponse } from '@/types/project'
+
+// ---------------------------------------------------------------------------
+// Shared mock data
+// ---------------------------------------------------------------------------
+
+const MOCK_PROJECTS: ProjectSummary[] = [
+  {
+    id: 1,
+    title: 'React 기반 강의 평가 플랫폼',
+    summary: '학생들이 익명으로 강의를 평가하고 정보를 공유하는 웹 서비스',
+    year: 2024,
+    semester: 1,
+    subjectName: '웹프로그래밍',
+    teamName: '코딩마스터즈',
+    techStacks: ['React', 'TypeScript', 'Spring Boot', 'MySQL'],
+    tags: ['웹', '평가', '익명'],
+    status: 'APPROVED',
+    viewCount: 142,
+    downloadCount: 23,
+    createdAt: '2024-06-01T12:00:00Z',
+  },
+  {
+    id: 2,
+    title: 'FastAPI + PyTorch 감성 분석 API',
+    summary: '한국어 리뷰 텍스트의 긍/부정을 분류하는 REST API 서버',
+    year: 2024,
+    semester: 1,
+    subjectName: '인공지능',
+    teamName: '',
+    techStacks: ['Python', 'FastAPI', 'PyTorch', 'HuggingFace'],
+    tags: ['NLP', '감성분석'],
+    status: 'APPROVED',
+    viewCount: 88,
+    downloadCount: 17,
+    createdAt: '2024-06-10T09:00:00Z',
+  },
+  {
+    id: 3,
+    title: '모바일 캘린더 + Todo 앱',
+    summary: '일정 관리와 할일 목록을 통합한 React Native 모바일 앱',
+    year: 2023,
+    semester: 2,
+    subjectName: '모바일프로그래밍',
+    teamName: '넷이서하나',
+    techStacks: ['React Native', 'Expo', 'Firebase'],
+    tags: ['모바일', '일정관리'],
+    status: 'APPROVED',
+    viewCount: 61,
+    downloadCount: 9,
+    createdAt: '2024-01-15T10:30:00Z',
+  },
+  {
+    id: 4,
+    title: 'Spring Boot + PostgreSQL 도서관 관리 시스템',
+    summary: '도서 대출/반납, 회원 관리, 연체료 계산 기능을 갖춘 관리 시스템',
+    year: 2024,
+    semester: 2,
+    subjectName: '데이터베이스',
+    teamName: '쿼리마스터',
+    techStacks: ['Spring Boot', 'Java', 'PostgreSQL', 'Thymeleaf'],
+    tags: ['백엔드', '관리시스템', 'CRUD'],
+    status: 'APPROVED',
+    viewCount: 75,
+    downloadCount: 12,
+    createdAt: '2024-12-10T08:00:00Z',
+  },
+  {
+    id: 5,
+    title: 'YOLOv8 기반 교내 마스크 착용 감지 시스템',
+    summary: '실시간 CCTV 영상에서 마스크 미착용자를 감지하고 알림을 전송하는 AI 시스템',
+    year: 2023,
+    semester: 1,
+    subjectName: '컴퓨터비전',
+    teamName: '비전팀',
+    techStacks: ['Python', 'YOLOv8', 'OpenCV', 'FastAPI'],
+    tags: ['컴퓨터비전', 'AI', '객체감지'],
+    status: 'APPROVED',
+    viewCount: 203,
+    downloadCount: 45,
+    createdAt: '2023-06-20T14:00:00Z',
+  },
+  {
+    id: 6,
+    title: 'Next.js + Supabase 중고 거래 플랫폼',
+    summary: '교내 학생 간 중고 물품 거래를 위한 실시간 채팅 포함 마켓플레이스',
+    year: 2025,
+    semester: 1,
+    subjectName: '캡스톤디자인',
+    teamName: '마켓팀',
+    techStacks: ['Next.js', 'TypeScript', 'Supabase', 'Tailwind CSS'],
+    tags: ['캡스톤', '실시간', '거래'],
+    status: 'APPROVED',
+    viewCount: 317,
+    downloadCount: 58,
+    createdAt: '2025-06-05T10:00:00Z',
+  },
+  {
+    id: 7,
+    title: 'Flutter 헬스케어 걸음수 트래커',
+    summary: '걸음수, 칼로리, 이동 경로를 기록하고 주간 리포트를 제공하는 크로스플랫폼 앱',
+    year: 2024,
+    semester: 2,
+    subjectName: '모바일프로그래밍',
+    teamName: '',
+    techStacks: ['Flutter', 'Dart', 'Firebase', 'Google Maps API'],
+    tags: ['헬스케어', '모바일', '트래커'],
+    status: 'APPROVED',
+    viewCount: 52,
+    downloadCount: 8,
+    createdAt: '2024-12-18T09:30:00Z',
+  },
+  {
+    id: 8,
+    title: 'GPT-4 활용 코드 리뷰 자동화 도구',
+    summary: 'GitHub PR에 올라온 코드를 자동으로 분석하여 리뷰 코멘트를 생성하는 CLI 도구',
+    year: 2025,
+    semester: 1,
+    subjectName: '소프트웨어공학',
+    teamName: 'AutoReview',
+    techStacks: ['Python', 'OpenAI API', 'GitHub Actions', 'Click'],
+    tags: ['AI', 'DevOps', '자동화'],
+    status: 'APPROVED',
+    viewCount: 189,
+    downloadCount: 34,
+    createdAt: '2025-05-30T11:00:00Z',
+  },
+  {
+    id: 9,
+    title: 'Vue.js + Django 교내 동아리 모집 게시판',
+    summary: '동아리 정보 조회, 모집 공고 등록, 지원서 제출을 처리하는 원스톱 웹 서비스',
+    year: 2023,
+    semester: 2,
+    subjectName: '웹프레임워크',
+    teamName: '동아리팀',
+    techStacks: ['Vue.js', 'Django', 'SQLite', 'Bootstrap'],
+    tags: ['웹', '게시판', '동아리'],
+    status: 'APPROVED',
+    viewCount: 98,
+    downloadCount: 21,
+    createdAt: '2023-12-05T13:00:00Z',
+  },
+]
+
+const MOCK_DETAIL: ProjectDetail = {
+  ...MOCK_PROJECTS[0],
+  description:
+    '이 프로젝트는 충북대학교 학생들이 수강한 강의에 대해 익명으로 평가를 남기고 열람할 수 있는 서비스입니다. ' +
+    'React와 Spring Boot를 사용하였으며, MySQL에 데이터를 저장합니다.',
+  members: [
+    { name: '김민준', studentId: '2021000001', role: '팀장' },
+    { name: '이서연', studentId: '2021000002', role: '백엔드' },
+  ],
+  visibility: 'PUBLIC',
+  files: [],
+}
+
+// ---------------------------------------------------------------------------
+// MSW request handlers
+// ---------------------------------------------------------------------------
+
+export const handlers = [
+  // GET /api/projects (keyword search)
+  http.get('/api/search', ({ request }) => {
+    const url = new URL(request.url)
+    const q = url.searchParams.get('q') ?? ''
+    const page = Number(url.searchParams.get('page') ?? 1)
+    const size = Number(url.searchParams.get('size') ?? 10)
+
+    const filtered = MOCK_PROJECTS.filter(
+      (p) =>
+        p.title.includes(q) ||
+        p.summary.includes(q) ||
+        p.techStacks.some((t) => t.toLowerCase().includes(q.toLowerCase())),
+    )
+
+    const pagedResponse: PagedResponse<ProjectSummary> = {
+      items: filtered.slice((page - 1) * size, page * size),
+      total: filtered.length,
+      page,
+      size,
+    }
+
+    return HttpResponse.json(pagedResponse)
+  }),
+
+  // GET /api/projects/:id
+  http.get('/api/projects/:id', ({ params }) => {
+    const id = Number(params.id)
+    const found = MOCK_PROJECTS.find((p) => p.id === id)
+    if (!found) return new HttpResponse(null, { status: 404 })
+    return HttpResponse.json({ ...MOCK_DETAIL, ...found })
+  }),
+
+  // POST /api/auth/login
+  http.post('/api/auth/login', async ({ request }) => {
+    const body = (await request.json()) as { identifier: string; password: string }
+
+    if (!body.identifier || !body.password) {
+      return HttpResponse.json({ message: '아이디와 비밀번호를 입력해주세요.' }, { status: 400 })
+    }
+
+    // admin / admin1234 → ADMIN 권한 (임시 개발 계정)
+    const isAdmin = body.identifier === 'admin' && body.password === 'admin1234'
+
+    return HttpResponse.json({
+      accessToken: isAdmin ? 'mock-admin-token' : 'mock-student-token',
+      userId: isAdmin ? 999 : 1,
+      role: isAdmin ? 'ADMIN' : 'STUDENT',
+    })
+  }),
+
+  // POST /api/auth/refresh
+  http.post('/api/auth/refresh', () =>
+    HttpResponse.json({ accessToken: 'mock-access-token-refreshed' }),
+  ),
+
+  // --------------------------------------------------------------------------
+  // AI 서비스 mock — localhost:8000이 미실행 상태일 때 MSW가 대신 응답
+  // --------------------------------------------------------------------------
+  http.post('http://localhost:8000/search', async ({ request }) => {
+    const body = (await request.json()) as { query: string; top_k?: number }
+    const q = (body.query ?? '').toLowerCase()
+    const topK = body.top_k ?? 5
+
+    // 쿼리 키워드를 기반으로 관련 프로젝트를 선별
+    const matched = MOCK_PROJECTS.filter(
+      (p) =>
+        p.title.toLowerCase().includes(q) ||
+        p.summary.toLowerCase().includes(q) ||
+        p.techStacks.some((t) => t.toLowerCase().includes(q)) ||
+        p.tags.some((t) => t.toLowerCase().includes(q)),
+    ).slice(0, topK)
+
+    // 매칭 없으면 전체에서 상위 topK 반환
+    const results = matched.length > 0 ? matched : MOCK_PROJECTS.slice(0, topK)
+
+    return HttpResponse.json({
+      query: body.query,
+      count: results.length,
+      results: results.map((p, i) => ({
+        project_id: p.id,
+        title: p.title,
+        topic: p.subjectName,
+        tech_stack: p.techStacks,
+        keywords: p.tags,
+        difficulty: '중급',
+        project_type: p.teamName ? '팀 프로젝트' : '개인 프로젝트',
+        rank: i + 1,
+        final_score: parseFloat((0.95 - i * 0.08).toFixed(2)),
+        reasons: [
+          `${p.techStacks[0] ?? '관련 기술'} 사용 프로젝트`,
+          `${p.subjectName} 과목 수행`,
+        ],
+      })),
+      llm_answer: `"${body.query}"에 관련된 ${results.length}개의 프로젝트를 찾았습니다. (MSW 목 응답)`,
+    })
+  }),
+]

--- a/frontend/src/pages/Chat.tsx
+++ b/frontend/src/pages/Chat.tsx
@@ -1,8 +1,180 @@
+import { useState, useRef, useEffect } from 'react'
+import { useChatStore } from '@/store/chatStore'
+import { searchNaturalDirect } from '@/api/search'
+import { ProjectCard } from '@/components/project/ProjectCard'
+import type { NaturalSearchResultItem } from '@/types/chat'
+import type { ProjectSummary } from '@/types/project'
+
+// Convert AI result item to ProjectSummary for display in chat bubbles
+function toProjectSummary(item: NaturalSearchResultItem): ProjectSummary {
+  return {
+    id: item.project_id,
+    title: item.title,
+    summary: item.topic,
+    year: 0,
+    semester: 1,
+    subjectName: item.project_type,
+    teamName: '',
+    techStacks: item.tech_stack,
+    tags: item.keywords,
+    status: 'APPROVED',
+    viewCount: 0,
+    downloadCount: 0,
+    createdAt: '',
+  }
+}
+
+// Each message in the conversation (extends base ChatMessage with AI result metadata)
+interface DisplayMessage {
+  role: 'user' | 'assistant'
+  content: string
+  projects?: ProjectSummary[]
+  matchReasonMap?: Record<number, string[]>  // project_id → reasons
+}
+
 export default function Chat() {
+  const { isLoading, setLoading } = useChatStore()
+  const [messages, setMessages] = useState<DisplayMessage[]>([])
+  const [input, setInput] = useState('')
+  const [error, setError] = useState<string | null>(null)
+  const bottomRef = useRef<HTMLDivElement>(null)
+
+  // Auto-scroll to bottom whenever a new message arrives
+  useEffect(() => {
+    bottomRef.current?.scrollIntoView({ behavior: 'smooth' })
+  }, [messages])
+
+  const sendMessage = async () => {
+    const text = input.trim()
+    if (!text || isLoading) return
+
+    setInput('')
+    setError(null)
+
+    // Append user message immediately so the UI feels responsive
+    const userMsg: DisplayMessage = { role: 'user', content: text }
+    setMessages((prev) => [...prev, userMsg])
+    setLoading(true)
+
+    try {
+      const result = await searchNaturalDirect(text)
+
+      // Build project list and reason map from AI results
+      const projects = result.results.map(toProjectSummary)
+      const reasonMap: Record<number, string[]> = {}
+      result.results.forEach((item) => {
+        reasonMap[item.project_id] = item.reasons
+      })
+
+      const assistantMsg: DisplayMessage = {
+        role: 'assistant',
+        content: result.llm_answer ?? '관련 프로젝트를 찾았습니다.',
+        projects,
+        matchReasonMap: reasonMap,
+      }
+      setMessages((prev) => [...prev, assistantMsg])
+    } catch {
+      setError('AI 서비스 응답 중 오류가 발생했습니다. 서버 상태를 확인해주세요.')
+      // Remove the optimistic user message on failure
+      setMessages((prev) => prev.slice(0, -1))
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    // Submit with Enter; allow newline with Shift+Enter
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault()
+      sendMessage()
+    }
+  }
+
   return (
-    <div>
-      <h1 className="mb-6 text-2xl font-bold text-gray-900">AI 챗봇 탐색</h1>
-      <p className="text-gray-500">채팅 메시지 버블, 입력창 컴포넌트는 이후 단계에서 구현됩니다.</p>
+    <div className="flex h-[calc(100vh-8rem)] flex-col">
+      <h1 className="mb-4 shrink-0 text-2xl font-bold text-gray-900">AI 챗봇 탐색</h1>
+
+      {/* Message history */}
+      <div className="flex flex-1 flex-col gap-4 overflow-y-auto rounded-xl border border-gray-200 bg-gray-50 px-4 py-4">
+        {messages.length === 0 && !isLoading && (
+          <div className="flex flex-1 flex-col items-center justify-center gap-2 text-gray-400">
+            <p className="text-lg font-medium">무엇이든 물어보세요.</p>
+            <p className="text-sm">예: "React 사용한 팀 프로젝트 추천해줘"</p>
+          </div>
+        )}
+
+        {messages.map((msg, idx) => (
+          <div
+            key={idx}
+            className={`flex ${msg.role === 'user' ? 'justify-end' : 'justify-start'}`}
+          >
+            <div
+              className={`max-w-xl rounded-2xl px-4 py-3 text-sm leading-relaxed ${
+                msg.role === 'user'
+                  ? 'bg-primary-600 text-white'
+                  : 'bg-white shadow-sm border border-gray-200 text-gray-800'
+              }`}
+            >
+              <p className="whitespace-pre-wrap">{msg.content}</p>
+
+              {/* Related projects shown inside assistant bubble */}
+              {msg.role === 'assistant' && msg.projects && msg.projects.length > 0 && (
+                <div className="mt-3 flex flex-col gap-2">
+                  <p className="text-xs font-semibold text-gray-500">관련 프로젝트</p>
+                  {msg.projects.map((project) => (
+                    <ProjectCard
+                      key={project.id}
+                      project={project}
+                      matchReasons={msg.matchReasonMap?.[project.id]}
+                    />
+                  ))}
+                </div>
+              )}
+            </div>
+          </div>
+        ))}
+
+        {/* Loading indicator while waiting for AI */}
+        {isLoading && (
+          <div className="flex justify-start">
+            <div className="rounded-2xl border border-gray-200 bg-white px-4 py-3 shadow-sm">
+              <div className="flex gap-1.5">
+                <span className="h-2 w-2 animate-bounce rounded-full bg-gray-400 [animation-delay:0ms]" />
+                <span className="h-2 w-2 animate-bounce rounded-full bg-gray-400 [animation-delay:150ms]" />
+                <span className="h-2 w-2 animate-bounce rounded-full bg-gray-400 [animation-delay:300ms]" />
+              </div>
+            </div>
+          </div>
+        )}
+
+        {error && (
+          <p className="rounded-xl border border-red-200 bg-red-50 px-4 py-2 text-sm text-red-700">
+            {error}
+          </p>
+        )}
+
+        {/* Anchor element — auto-scroll lands here */}
+        <div ref={bottomRef} />
+      </div>
+
+      {/* Input bar */}
+      <div className="mt-3 shrink-0 flex gap-2">
+        <textarea
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          onKeyDown={handleKeyDown}
+          placeholder="프로젝트를 자연어로 검색해보세요... (Enter로 전송, Shift+Enter로 줄바꿈)"
+          rows={2}
+          className="flex-1 resize-none rounded-xl border border-gray-300 px-4 py-2.5 text-sm outline-none focus:border-primary-500 focus:ring-2 focus:ring-primary-100"
+        />
+        <button
+          onClick={sendMessage}
+          disabled={isLoading || !input.trim()}
+          className="self-end rounded-xl bg-primary-600 px-5 py-2.5 text-sm font-semibold text-white transition hover:bg-primary-700 disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          전송
+        </button>
+      </div>
     </div>
   )
 }

--- a/frontend/src/pages/ProjectList.tsx
+++ b/frontend/src/pages/ProjectList.tsx
@@ -1,8 +1,168 @@
+import { useState, useCallback, useEffect } from 'react'
+import { SearchBar } from '@/components/search/SearchBar'
+import { FilterPanel } from '@/components/search/FilterPanel'
+import { ProjectCard } from '@/components/project/ProjectCard'
+import { useSearchStore } from '@/store/searchStore'
+import { searchNaturalDirect, searchKeyword } from '@/api/search'
+import type { NaturalSearchResultItem, NaturalSearchResult } from '@/types/chat'
+import type { ProjectSummary } from '@/types/project'
+
+// Map AI service result item to the ProjectSummary shape ProjectCard expects
+function toProjectSummary(item: NaturalSearchResultItem): ProjectSummary {
+  return {
+    id: item.project_id,
+    title: item.title,
+    summary: item.topic,
+    year: 0,
+    semester: 1,
+    subjectName: item.project_type,
+    teamName: '',
+    techStacks: item.tech_stack,
+    tags: item.keywords,
+    status: 'APPROVED',
+    viewCount: 0,
+    downloadCount: 0,
+    createdAt: '',
+  }
+}
+
 export default function ProjectList() {
+  const { keyword, searchType, filters } = useSearchStore()
+
+  const [isLoading, setIsLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  // Natural search state
+  const [naturalResult, setNaturalResult] = useState<NaturalSearchResult | null>(null)
+
+  // Keyword search state (backend stub); pre-populated on mount
+  const [keywordProjects, setKeywordProjects] = useState<ProjectSummary[]>([])
+
+  // Load all projects on first render so the page isn't empty
+  useEffect(() => {
+    searchKeyword({ q: '', sort: 'latest', page: 1, size: 20 })
+      .then((page) => setKeywordProjects(page.items ?? []))
+      .catch(() => {/* silently skip if backend/MSW not available */})
+  }, [])
+
+  const handleSearch = useCallback(async () => {
+    // Natural search always requires a query
+    if (searchType === 'natural' && !keyword.trim()) return
+    setIsLoading(true)
+    setError(null)
+    setNaturalResult(null)
+    setKeywordProjects([])
+
+    try {
+      if (searchType === 'natural') {
+        // Call AI service directly while backend proxy is not implemented
+        const result = await searchNaturalDirect(keyword)
+        setNaturalResult(result)
+      } else {
+        // Keyword search through backend; returns empty list until backend is ready
+        const page = await searchKeyword({
+          q: keyword,
+          sort: 'latest',
+          page: 1,
+          size: 20,
+        })
+        setKeywordProjects(page.items ?? [])
+      }
+    } catch (e) {
+      setError('검색 중 오류가 발생했습니다. 서버 상태를 확인해주세요.')
+    } finally {
+      setIsLoading(false)
+    }
+  }, [keyword, searchType, filters])
+
+  // Derive display list from whichever search mode is active
+  const naturalItems = naturalResult?.results ?? []
+  const displayProjects = searchType === 'keyword' ? keywordProjects : []
+  // Consider page "has results" when there's anything to show
+  const hasResults = searchType === 'natural' ? naturalItems.length > 0 : displayProjects.length > 0
+
   return (
-    <div>
-      <h1 className="mb-6 text-2xl font-bold text-gray-900">프로젝트 목록</h1>
-      <p className="text-gray-500">검색·필터·카드 컴포넌트는 이후 단계에서 구현됩니다.</p>
+    <div className="flex flex-col gap-6">
+      <h1 className="text-2xl font-bold text-gray-900">프로젝트 목록</h1>
+
+      <SearchBar onSearch={handleSearch} />
+
+      <div className="flex gap-6">
+        {/* Sidebar filter — hidden on small screens */}
+        <aside className="hidden w-56 shrink-0 lg:block">
+          <FilterPanel />
+        </aside>
+
+        {/* Main results area */}
+        <section className="min-w-0 flex-1">
+          {/* AI LLM summary box */}
+          {naturalResult?.llm_answer && (
+            <div className="mb-5 rounded-xl border border-blue-200 bg-blue-50 px-4 py-3 text-sm text-blue-800">
+              <p className="mb-1 font-semibold">AI 답변</p>
+              <p className="leading-relaxed">{naturalResult.llm_answer}</p>
+            </div>
+          )}
+
+          {/* Loading skeleton */}
+          {isLoading && (
+            <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
+              {Array.from({ length: 6 }).map((_, i) => (
+                <div key={i} className="h-44 animate-pulse rounded-xl bg-gray-100" />
+              ))}
+            </div>
+          )}
+
+          {/* Error message */}
+          {!isLoading && error && (
+            <p className="rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
+              {error}
+            </p>
+          )}
+
+          {/* Empty state — shown only after a search is triggered */}
+          {!isLoading && !error && !hasResults && (keyword.trim() !== '') && (
+            <div className="flex flex-col items-center gap-2 py-16 text-gray-400">
+              <p className="text-lg font-medium">검색 결과가 없습니다.</p>
+              <p className="text-sm">다른 키워드나 AI 자연어 검색을 시도해보세요.</p>
+            </div>
+          )}
+
+          {/* Initial state — show all projects (no search yet) */}
+          {!isLoading && !error && keyword.trim() === '' && searchType === 'natural' && (
+            <div className="flex flex-col items-center gap-2 py-16 text-gray-400">
+              <p className="text-lg font-medium">AI에게 자유롭게 질문해보세요.</p>
+              <p className="text-sm">예: "React로 만든 팀 프로젝트 추천해줘"</p>
+            </div>
+          )}
+
+          {/* Natural search results */}
+          {!isLoading && searchType === 'natural' && naturalItems.length > 0 && (
+            <>
+              <p className="mb-3 text-sm text-gray-500">
+                총 <span className="font-semibold text-gray-800">{naturalResult!.count}</span>개의 프로젝트를 찾았습니다.
+              </p>
+              <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
+                {naturalItems.map((item) => (
+                  <ProjectCard
+                    key={item.project_id}
+                    project={toProjectSummary(item)}
+                    matchReasons={item.reasons}
+                  />
+                ))}
+              </div>
+            </>
+          )}
+
+          {/* Keyword search results */}
+          {!isLoading && searchType === 'keyword' && displayProjects.length > 0 && (
+            <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
+              {displayProjects.map((project) => (
+                <ProjectCard key={project.id} project={project} />
+              ))}
+            </div>
+          )}
+        </section>
+      </div>
     </div>
   )
 }

--- a/frontend/src/store/authStore.ts
+++ b/frontend/src/store/authStore.ts
@@ -1,4 +1,5 @@
 import { create } from 'zustand'
+import { persist } from 'zustand/middleware'
 import type { UserRole } from '@/types/user'
 
 interface AuthState {
@@ -10,11 +11,17 @@ interface AuthState {
   logout: () => void
 }
 
-export const useAuthStore = create<AuthState>((set) => ({
-  accessToken: null,
-  userId: null,
-  role: 'GUEST',
-  setAuth: (accessToken, userId, role) => set({ accessToken, userId, role }),
-  setAccessToken: (accessToken) => set({ accessToken }),
-  logout: () => set({ accessToken: null, userId: null, role: 'GUEST' }),
-}))
+export const useAuthStore = create<AuthState>()(
+  // Persist to localStorage so login survives page refresh
+  persist(
+    (set) => ({
+      accessToken: null,
+      userId: null,
+      role: 'GUEST',
+      setAuth: (accessToken, userId, role) => set({ accessToken, userId, role }),
+      setAccessToken: (accessToken) => set({ accessToken }),
+      logout: () => set({ accessToken: null, userId: null, role: 'GUEST' }),
+    }),
+    { name: 'cbnu-auth' },
+  ),
+)

--- a/frontend/src/types/chat.ts
+++ b/frontend/src/types/chat.ts
@@ -19,8 +19,23 @@ export interface ChatResponse {
   suggestedFollowUps: string[]
 }
 
+// Matches actual AI service response shape from POST /search
+export interface NaturalSearchResultItem {
+  project_id: number
+  title: string
+  topic: string
+  tech_stack: string[]
+  keywords: string[]
+  difficulty: string
+  project_type: string
+  rank: number
+  final_score: number
+  reasons: string[]
+}
+
 export interface NaturalSearchResult {
-  interpretedConditions: Record<string, unknown>
-  answer: string
-  projects: (ProjectSummary & { matchReason: string })[]
+  query: string
+  count: number
+  results: NaturalSearchResultItem[]
+  llm_answer: string | null
 }


### PR DESCRIPTION
## 개요
백엔드 미구현 상태에서 AI 서비스를 활용한 핵심 UI를 구현하고, MSW로 로컬 개발 환경을 구성합니다.

## 변경 사항
- `types/chat.ts` — NaturalSearchResult 타입을 실제 AI 서비스 응답 형태로 수정
- 공통 UI 컴포넌트 신규 추가: Button, Input, ProjectStatusBadge, ProjectCard, SearchBar, FilterPanel
- `api/search.ts` — AI 서비스 직접 호출용 searchNaturalDirect() 추가
- `ProjectList.tsx` — 키워드/AI 자연어 검색 분기, 진입 시 전체 목록 자동 로드
- `Chat.tsx` — 대화형 메시지 버블, 관련 프로젝트 인라인 표시
- MSW 세팅: handlers.ts(9개 더미 프로젝트 + AI mock), browser.ts, main.tsx VITE_USE_MSW 플래그
- `authStore.ts` — localStorage persist로 새로고침 후에도 로그인 유지

## 로컬 실행 방법
```bash
# frontend/.env.local
VITE_USE_MSW=true
VITE_API_BASE_URL=

cd frontend && npm run dev
# admin 계정: admin / admin1234
```

### 비고
백엔드 API 완성 시 VITE_USE_MSW=false로 변경
AI 서비스(localhost:8000) 미실행 시 MSW가 /search까지 목 응답 처리