### PR TITLE
[FEAT(backend)] 백엔드 초기 구조 및 핵심 도메인 구현

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -31,6 +31,11 @@ dependencies {
 	implementation 'org.flywaydb:flyway-core'
 	implementation 'org.flywaydb:flyway-database-postgresql'
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.16'
+	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+	implementation 'jakarta.validation:jakarta.validation-api'
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	runtimeOnly 'org.postgresql:postgresql'
@@ -40,6 +45,11 @@ dependencies {
 	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
+
+// implementation 'io.jsonwebtoken:jjwt-api:0.12.5'
+// runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.5'
+// runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.5'
+
 
 tasks.named('test') {
 	useJUnitPlatform()

--- a/backend/src/main/java/com/ctrl/cbnu_archive/CbnuArchiveApplication.java
+++ b/backend/src/main/java/com/ctrl/cbnu_archive/CbnuArchiveApplication.java
@@ -2,12 +2,13 @@ package com.ctrl.cbnu_archive;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing
 public class CbnuArchiveApplication {
 
-	public static void main(String[] args) {
-		SpringApplication.run(CbnuArchiveApplication.class, args);
-	}
-
+    public static void main(String[] args) {
+        SpringApplication.run(CbnuArchiveApplication.class, args);
+    }
 }

--- a/backend/src/main/java/com/ctrl/cbnu_archive/auth/controller/AuthController.java
+++ b/backend/src/main/java/com/ctrl/cbnu_archive/auth/controller/AuthController.java
@@ -1,0 +1,53 @@
+package com.ctrl.cbnu_archive.auth.controller;
+
+import com.ctrl.cbnu_archive.auth.dto.LoginRequest;
+import com.ctrl.cbnu_archive.auth.dto.RefreshTokenRequest;
+import com.ctrl.cbnu_archive.auth.dto.SignUpRequest;
+import com.ctrl.cbnu_archive.auth.dto.TokenResponse;
+import com.ctrl.cbnu_archive.auth.dto.UserResponse;
+import com.ctrl.cbnu_archive.auth.service.AuthService;
+import com.ctrl.cbnu_archive.global.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/auth")
+@Tag(name = "Auth", description = "인증 API")
+public class AuthController {
+
+    private final AuthService authService;
+
+    public AuthController(AuthService authService) {
+        this.authService = authService;
+    }
+
+    @Operation(summary = "회원가입", description = "새로운 사용자를 등록합니다.")
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "회원가입 성공", content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = @Schema(implementation = UserResponse.class)))
+    @PostMapping("/signup")
+    public ApiResponse<UserResponse> signUp(@Valid @RequestBody SignUpRequest request) {
+        return ApiResponse.success(authService.signUp(request));
+    }
+
+    @Operation(summary = "로그인", description = "이메일과 비밀번호로 로그인하고 JWT를 발급합니다.")
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "로그인 성공", content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = @Schema(implementation = TokenResponse.class)))
+    @PostMapping("/login")
+    public ApiResponse<TokenResponse> login(@Valid @RequestBody LoginRequest request) {
+        return ApiResponse.success(authService.login(request));
+    }
+
+    @Operation(summary = "토큰 재발급", description = "리프레시 토큰으로 엑세스 토큰을 재발급합니다.")
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "토큰 재발급 성공", content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = @Schema(implementation = TokenResponse.class)))
+    @PostMapping("/reissue")
+    public ApiResponse<TokenResponse> reissue(@Valid @RequestBody RefreshTokenRequest request) {
+        return ApiResponse.success(authService.reissue(request.refreshToken()));
+    }
+}

--- a/backend/src/main/java/com/ctrl/cbnu_archive/auth/controller/UserController.java
+++ b/backend/src/main/java/com/ctrl/cbnu_archive/auth/controller/UserController.java
@@ -1,0 +1,62 @@
+package com.ctrl.cbnu_archive.auth.controller;
+
+import com.ctrl.cbnu_archive.auth.dto.PasswordChangeRequest;
+import com.ctrl.cbnu_archive.auth.dto.UserResponse;
+import com.ctrl.cbnu_archive.auth.dto.UserUpdateRequest;
+import com.ctrl.cbnu_archive.auth.service.UserService;
+import com.ctrl.cbnu_archive.global.response.ApiResponse;
+import com.ctrl.cbnu_archive.global.security.jwt.CustomUserDetails;
+import com.ctrl.cbnu_archive.project.dto.ProjectResponse;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import jakarta.validation.Valid;
+
+@RestController
+@RequestMapping("/api/v1/users")
+public class UserController {
+
+    private final UserService userService;
+
+    public UserController(UserService userService) {
+        this.userService = userService;
+    }
+
+    @GetMapping("/me")
+    public ResponseEntity<ApiResponse<UserResponse>> getMyInfo(
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
+        UserResponse response = userService.getMyInfo(userDetails.getId());
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    @PatchMapping("/me")
+    public ResponseEntity<ApiResponse<UserResponse>> updateMyInfo(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @Valid @RequestBody UserUpdateRequest request) {
+        UserResponse response = userService.updateMyInfo(userDetails.getId(), request);
+        return ResponseEntity.ok(ApiResponse.success(response));
+    }
+
+    @PatchMapping("/me/password")
+    public ResponseEntity<ApiResponse<Void>> changePassword(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @Valid @RequestBody PasswordChangeRequest request) {
+        userService.changePassword(userDetails.getId(), request);
+        return ResponseEntity.ok(ApiResponse.success(null));
+    }
+
+    @GetMapping("/me/projects")
+    public ResponseEntity<ApiResponse<Page<ProjectResponse>>> getMyProjects(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            Pageable pageable) {
+        Page<ProjectResponse> projects = userService.getMyProjects(userDetails.getId(), pageable);
+        return ResponseEntity.ok(ApiResponse.success(projects));
+    }
+}

--- a/backend/src/main/java/com/ctrl/cbnu_archive/auth/domain/User.java
+++ b/backend/src/main/java/com/ctrl/cbnu_archive/auth/domain/User.java
@@ -1,0 +1,89 @@
+package com.ctrl.cbnu_archive.auth.domain;
+
+import com.ctrl.cbnu_archive.global.domain.BaseTimeEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.util.Objects;
+
+@Entity
+@Table(name = "users")
+public class User extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true)
+    private String email;
+
+    @Column(nullable = false)
+    private String password;
+
+    @Column(nullable = false)
+    private String name;
+
+    @Column(unique = true)
+    private String studentNumber;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private UserRole role = UserRole.USER;
+
+    protected User() {
+    }
+
+    private User(String email, String password, String name, String studentNumber, UserRole role) {
+        this.email = Objects.requireNonNull(email, "email must not be null");
+        this.password = Objects.requireNonNull(password, "password must not be null");
+        this.name = Objects.requireNonNull(name, "name must not be null");
+        this.studentNumber = studentNumber;
+        this.role = role == null ? UserRole.USER : role;
+    }
+
+    public static User create(String email, String password, String name, String studentNumber) {
+        return new User(email, password, name, studentNumber, UserRole.USER);
+    }
+
+    public static User create(String email, String password, String name, String studentNumber, UserRole role) {
+        return new User(email, password, name, studentNumber, role);
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getStudentNumber() {
+        return studentNumber;
+    }
+
+    public UserRole getRole() {
+        return role;
+    }
+
+    public void updatePassword(String encodedPassword) {
+        this.password = Objects.requireNonNull(encodedPassword, "encodedPassword must not be null");
+    }
+
+    public void updateProfile(String name, String studentNumber) {
+        this.name = Objects.requireNonNull(name, "name must not be null");
+        this.studentNumber = studentNumber;
+    }
+}

--- a/backend/src/main/java/com/ctrl/cbnu_archive/auth/domain/UserRole.java
+++ b/backend/src/main/java/com/ctrl/cbnu_archive/auth/domain/UserRole.java
@@ -1,0 +1,6 @@
+package com.ctrl.cbnu_archive.auth.domain;
+
+public enum UserRole {
+    USER,
+    ADMIN
+}

--- a/backend/src/main/java/com/ctrl/cbnu_archive/auth/dto/LoginRequest.java
+++ b/backend/src/main/java/com/ctrl/cbnu_archive/auth/dto/LoginRequest.java
@@ -1,0 +1,13 @@
+package com.ctrl.cbnu_archive.auth.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+public record LoginRequest(
+        @Email(message = "유효한 이메일을 입력해주세요")
+        @NotBlank(message = "이메일은 필수입니다")
+        String email,
+        @NotBlank(message = "비밀번호는 필수입니다")
+        String password
+) {
+}

--- a/backend/src/main/java/com/ctrl/cbnu_archive/auth/dto/PasswordChangeRequest.java
+++ b/backend/src/main/java/com/ctrl/cbnu_archive/auth/dto/PasswordChangeRequest.java
@@ -1,0 +1,7 @@
+package com.ctrl.cbnu_archive.auth.dto;
+
+public record PasswordChangeRequest(
+        String currentPassword,
+        String newPassword
+) {
+}

--- a/backend/src/main/java/com/ctrl/cbnu_archive/auth/dto/RefreshTokenRequest.java
+++ b/backend/src/main/java/com/ctrl/cbnu_archive/auth/dto/RefreshTokenRequest.java
@@ -1,0 +1,9 @@
+package com.ctrl.cbnu_archive.auth.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record RefreshTokenRequest(
+        @NotBlank(message = "refreshToken은 필수입니다")
+        String refreshToken
+) {
+}

--- a/backend/src/main/java/com/ctrl/cbnu_archive/auth/dto/SignUpRequest.java
+++ b/backend/src/main/java/com/ctrl/cbnu_archive/auth/dto/SignUpRequest.java
@@ -1,0 +1,19 @@
+package com.ctrl.cbnu_archive.auth.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record SignUpRequest(
+        @Email(message = "유효한 이메일을 입력해주세요")
+        @NotBlank(message = "이메일은 필수입니다")
+        String email,
+        @NotBlank(message = "비밀번호는 필수입니다")
+        @Size(min = 8, message = "비밀번호는 최소 8자 이상이어야 합니다")
+        String password,
+        @NotBlank(message = "이름은 필수입니다")
+        String name,
+        @NotBlank(message = "학번은 필수입니다")
+        String studentNumber
+) {
+}

--- a/backend/src/main/java/com/ctrl/cbnu_archive/auth/dto/TokenResponse.java
+++ b/backend/src/main/java/com/ctrl/cbnu_archive/auth/dto/TokenResponse.java
@@ -1,0 +1,11 @@
+package com.ctrl.cbnu_archive.auth.dto;
+
+public record TokenResponse(
+        String accessToken,
+        String refreshToken,
+        String tokenType
+) {
+    public TokenResponse(String accessToken, String refreshToken) {
+        this(accessToken, refreshToken, "Bearer");
+    }
+}

--- a/backend/src/main/java/com/ctrl/cbnu_archive/auth/dto/UserResponse.java
+++ b/backend/src/main/java/com/ctrl/cbnu_archive/auth/dto/UserResponse.java
@@ -1,0 +1,22 @@
+package com.ctrl.cbnu_archive.auth.dto;
+
+import com.ctrl.cbnu_archive.auth.domain.User;
+import com.ctrl.cbnu_archive.auth.domain.UserRole;
+
+public record UserResponse(
+        Long id,
+        String email,
+        String name,
+        String studentNumber,
+        UserRole role
+) {
+    public static UserResponse fromEntity(User user) {
+        return new UserResponse(
+                user.getId(),
+                user.getEmail(),
+                user.getName(),
+                user.getStudentNumber(),
+                user.getRole()
+        );
+    }
+}

--- a/backend/src/main/java/com/ctrl/cbnu_archive/auth/dto/UserUpdateRequest.java
+++ b/backend/src/main/java/com/ctrl/cbnu_archive/auth/dto/UserUpdateRequest.java
@@ -1,0 +1,7 @@
+package com.ctrl.cbnu_archive.auth.dto;
+
+public record UserUpdateRequest(
+        String name,
+        String studentNumber
+) {
+}

--- a/backend/src/main/java/com/ctrl/cbnu_archive/auth/exception/AuthException.java
+++ b/backend/src/main/java/com/ctrl/cbnu_archive/auth/exception/AuthException.java
@@ -1,0 +1,15 @@
+package com.ctrl.cbnu_archive.auth.exception;
+
+import com.ctrl.cbnu_archive.global.exception.CustomException;
+import com.ctrl.cbnu_archive.global.exception.ErrorCode;
+
+public class AuthException extends CustomException {
+
+    public AuthException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+
+    public AuthException(ErrorCode errorCode, String customMessage) {
+        super(errorCode, customMessage);
+    }
+}

--- a/backend/src/main/java/com/ctrl/cbnu_archive/auth/repository/UserRepository.java
+++ b/backend/src/main/java/com/ctrl/cbnu_archive/auth/repository/UserRepository.java
@@ -1,0 +1,13 @@
+package com.ctrl.cbnu_archive.auth.repository;
+
+import com.ctrl.cbnu_archive.auth.domain.User;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface UserRepository extends JpaRepository<User, Long> {
+    boolean existsByEmail(String email);
+    Optional<User> findByEmail(String email);
+    Optional<User> findByStudentNumber(String studentNumber);
+}

--- a/backend/src/main/java/com/ctrl/cbnu_archive/auth/service/AuthService.java
+++ b/backend/src/main/java/com/ctrl/cbnu_archive/auth/service/AuthService.java
@@ -1,0 +1,64 @@
+package com.ctrl.cbnu_archive.auth.service;
+
+import com.ctrl.cbnu_archive.auth.domain.User;
+import com.ctrl.cbnu_archive.auth.dto.LoginRequest;
+import com.ctrl.cbnu_archive.auth.dto.SignUpRequest;
+import com.ctrl.cbnu_archive.auth.dto.TokenResponse;
+import com.ctrl.cbnu_archive.auth.dto.UserResponse;
+import com.ctrl.cbnu_archive.auth.repository.UserRepository;
+import com.ctrl.cbnu_archive.auth.exception.AuthException;
+import com.ctrl.cbnu_archive.global.exception.ErrorCode;
+import com.ctrl.cbnu_archive.global.security.jwt.JwtTokenProvider;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+public class AuthService {
+
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final JwtTokenProvider jwtTokenProvider;
+
+    public AuthService(UserRepository userRepository,
+                       PasswordEncoder passwordEncoder,
+                       JwtTokenProvider jwtTokenProvider) {
+        this.userRepository = userRepository;
+        this.passwordEncoder = passwordEncoder;
+        this.jwtTokenProvider = jwtTokenProvider;
+    }
+
+    public UserResponse signUp(SignUpRequest request) {
+        if (userRepository.existsByEmail(request.email())) {
+            throw new AuthException(ErrorCode.DUPLICATE_EMAIL);
+        }
+        var encodedPassword = passwordEncoder.encode(request.password());
+        User user = User.create(request.email(), encodedPassword, request.name(), request.studentNumber());
+        User saved = userRepository.save(user);
+        return UserResponse.fromEntity(saved);
+    }
+
+    public TokenResponse login(LoginRequest request) {
+        User user = userRepository.findByEmail(request.email())
+                .orElseThrow(() -> new AuthException(ErrorCode.USER_NOT_FOUND));
+        if (!passwordEncoder.matches(request.password(), user.getPassword())) {
+            throw new AuthException(ErrorCode.INVALID_INPUT, "이메일 또는 비밀번호가 일치하지 않습니다.");
+        }
+        String accessToken = jwtTokenProvider.generateAccessToken(user.getId(), user.getEmail(), user.getRole());
+        String refreshToken = jwtTokenProvider.generateRefreshToken(user.getId());
+        return new TokenResponse(accessToken, refreshToken);
+    }
+
+    public TokenResponse reissue(String refreshToken) {
+        if (!jwtTokenProvider.validateToken(refreshToken)) {
+            throw new AuthException(ErrorCode.INVALID_TOKEN);
+        }
+        Long userId = jwtTokenProvider.getUserIdFromToken(refreshToken);
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new AuthException(ErrorCode.USER_NOT_FOUND));
+        String accessToken = jwtTokenProvider.generateAccessToken(user.getId(), user.getEmail(), user.getRole());
+        String newRefreshToken = jwtTokenProvider.generateRefreshToken(user.getId());
+        return new TokenResponse(accessToken, newRefreshToken);
+    }
+}

--- a/backend/src/main/java/com/ctrl/cbnu_archive/auth/service/UserService.java
+++ b/backend/src/main/java/com/ctrl/cbnu_archive/auth/service/UserService.java
@@ -1,0 +1,65 @@
+package com.ctrl.cbnu_archive.auth.service;
+
+import com.ctrl.cbnu_archive.auth.domain.User;
+import com.ctrl.cbnu_archive.auth.dto.PasswordChangeRequest;
+import com.ctrl.cbnu_archive.auth.dto.UserResponse;
+import com.ctrl.cbnu_archive.auth.dto.UserUpdateRequest;
+import com.ctrl.cbnu_archive.auth.exception.AuthException;
+import com.ctrl.cbnu_archive.auth.repository.UserRepository;
+import com.ctrl.cbnu_archive.global.exception.ErrorCode;
+import com.ctrl.cbnu_archive.project.dto.ProjectResponse;
+import com.ctrl.cbnu_archive.project.mapper.ProjectMapper;
+import com.ctrl.cbnu_archive.project.repository.ProjectRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+public class UserService {
+
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final ProjectRepository projectRepository;
+
+    public UserService(UserRepository userRepository,
+                       PasswordEncoder passwordEncoder,
+                       ProjectRepository projectRepository) {
+        this.userRepository = userRepository;
+        this.passwordEncoder = passwordEncoder;
+        this.projectRepository = projectRepository;
+    }
+
+    public UserResponse getMyInfo(Long userId) {
+        User user = loadUser(userId);
+        return UserResponse.fromEntity(user);
+    }
+
+    public UserResponse updateMyInfo(Long userId, UserUpdateRequest request) {
+        User user = loadUser(userId);
+        user.updateProfile(request.name(), request.studentNumber());
+        User updated = userRepository.save(user);
+        return UserResponse.fromEntity(updated);
+    }
+
+    public void changePassword(Long userId, PasswordChangeRequest request) {
+        User user = loadUser(userId);
+        if (!passwordEncoder.matches(request.currentPassword(), user.getPassword())) {
+            throw new AuthException(ErrorCode.INVALID_INPUT, "현재 비밀번호가 일치하지 않습니다.");
+        }
+        user.updatePassword(passwordEncoder.encode(request.newPassword()));
+        userRepository.save(user);
+    }
+
+    public Page<ProjectResponse> getMyProjects(Long userId, Pageable pageable) {
+        return projectRepository.findByAuthorId(userId, pageable)
+                .map(ProjectMapper::toResponse);
+    }
+
+    private User loadUser(Long userId) {
+        return userRepository.findById(userId)
+                .orElseThrow(() -> new AuthException(ErrorCode.USER_NOT_FOUND, "사용자를 찾을 수 없습니다."));
+    }
+}

--- a/backend/src/main/java/com/ctrl/cbnu_archive/file/controller/FileController.java
+++ b/backend/src/main/java/com/ctrl/cbnu_archive/file/controller/FileController.java
@@ -1,0 +1,70 @@
+package com.ctrl.cbnu_archive.file.controller;
+
+import com.ctrl.cbnu_archive.file.dto.FileResponse;
+import com.ctrl.cbnu_archive.file.dto.FileUploadResponse;
+import com.ctrl.cbnu_archive.file.service.FileService;
+import com.ctrl.cbnu_archive.global.response.ApiResponse;
+import com.ctrl.cbnu_archive.global.security.jwt.CustomUserDetails;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+@RestController
+@RequestMapping("/api/v1/files")
+@Tag(name = "File", description = "파일 업로드 및 다운로드 API")
+public class FileController {
+
+    private final FileService fileService;
+
+    public FileController(FileService fileService) {
+        this.fileService = fileService;
+    }
+
+    @Operation(summary = "프로젝트 파일 업로드", description = "프로젝트 작성자 또는 ADMIN이 파일을 업로드합니다.")
+    @PostMapping(value = "/projects/{projectId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ApiResponse<FileUploadResponse> uploadFile(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @PathVariable Long projectId,
+            @RequestParam("file") MultipartFile file
+    ) {
+        return ApiResponse.success(fileService.uploadFile(projectId, file, userDetails.getId(), userDetails.getAuthorities().stream().anyMatch(auth -> auth.getAuthority().equals("ROLE_ADMIN"))));
+    }
+
+    @Operation(summary = "프로젝트 파일 목록 조회", description = "프로젝트에 첨부된 파일 목록을 조회합니다.")
+    @GetMapping("/projects/{projectId}")
+    public ApiResponse<List<FileResponse>> listFiles(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @PathVariable Long projectId
+    ) {
+        return ApiResponse.success(fileService.listFilesByProject(projectId, userDetails.getId(), userDetails.getAuthorities().stream().anyMatch(auth -> auth.getAuthority().equals("ROLE_ADMIN"))));
+    }
+
+    @Operation(summary = "파일 상세 조회", description = "파일 메타데이터와 다운로드 URL을 조회합니다.")
+    @GetMapping("/{fileId}")
+    public ApiResponse<FileResponse> getFile(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @PathVariable Long fileId
+    ) {
+        return ApiResponse.success(fileService.getFile(fileId, userDetails.getId(), userDetails.getAuthorities().stream().anyMatch(auth -> auth.getAuthority().equals("ROLE_ADMIN"))));
+    }
+
+    @Operation(summary = "파일 삭제", description = "프로젝트 작성자 또는 ADMIN이 파일을 삭제합니다.")
+    @DeleteMapping("/{fileId}")
+    public ApiResponse<Void> deleteFile(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @PathVariable Long fileId
+    ) {
+        fileService.deleteFile(fileId, userDetails.getId(), userDetails.getAuthorities().stream().anyMatch(auth -> auth.getAuthority().equals("ROLE_ADMIN")));
+        return ApiResponse.success(null);
+    }
+}

--- a/backend/src/main/java/com/ctrl/cbnu_archive/file/domain/FileType.java
+++ b/backend/src/main/java/com/ctrl/cbnu_archive/file/domain/FileType.java
@@ -1,0 +1,21 @@
+package com.ctrl.cbnu_archive.file.domain;
+
+public enum FileType {
+    DOCUMENT,
+    IMAGE,
+    ATTACHMENT;
+
+    public static FileType fromContentType(String contentType) {
+        if (contentType == null) {
+            return ATTACHMENT;
+        }
+        String normalized = contentType.toLowerCase();
+        if (normalized.startsWith("image/")) {
+            return IMAGE;
+        }
+        if (normalized.contains("pdf") || normalized.contains("word") || normalized.contains("msword") || normalized.contains("sheet") || normalized.contains("excel") || normalized.contains("presentation") || normalized.contains("text")) {
+            return DOCUMENT;
+        }
+        return ATTACHMENT;
+    }
+}

--- a/backend/src/main/java/com/ctrl/cbnu_archive/file/domain/ProjectFile.java
+++ b/backend/src/main/java/com/ctrl/cbnu_archive/file/domain/ProjectFile.java
@@ -1,0 +1,93 @@
+package com.ctrl.cbnu_archive.file.domain;
+
+import com.ctrl.cbnu_archive.project.domain.Project;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import java.util.Objects;
+
+@Entity
+@Table(name = "project_files")
+public class ProjectFile {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String fileName;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private FileType fileType;
+
+    @Column(nullable = false)
+    private Long size;
+
+    @Column(nullable = false, unique = true)
+    private String storageKey;
+
+    @Column(nullable = false)
+    private LocalDateTime uploadedAt;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "project_id", nullable = false)
+    private Project project;
+
+    protected ProjectFile() {
+    }
+
+    private ProjectFile(String fileName, FileType fileType, Long size, String storageKey, LocalDateTime uploadedAt, Project project) {
+        this.fileName = Objects.requireNonNull(fileName, "fileName must not be null");
+        this.fileType = Objects.requireNonNull(fileType, "fileType must not be null");
+        this.size = Objects.requireNonNull(size, "size must not be null");
+        this.storageKey = Objects.requireNonNull(storageKey, "storageKey must not be null");
+        this.uploadedAt = Objects.requireNonNull(uploadedAt, "uploadedAt must not be null");
+        this.project = Objects.requireNonNull(project, "project must not be null");
+    }
+
+    public static ProjectFile create(String fileName, FileType fileType, Long size, String storageKey, Project project) {
+        return new ProjectFile(fileName, fileType, size, storageKey, LocalDateTime.now(), project);
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getFileName() {
+        return fileName;
+    }
+
+    public FileType getFileType() {
+        return fileType;
+    }
+
+    public Long getSize() {
+        return size;
+    }
+
+    public String getStorageKey() {
+        return storageKey;
+    }
+
+    public LocalDateTime getUploadedAt() {
+        return uploadedAt;
+    }
+
+    public Long getProjectId() {
+        return project.getId();
+    }
+
+    public Project getProject() {
+        return project;
+    }
+}

--- a/backend/src/main/java/com/ctrl/cbnu_archive/file/dto/FileResponse.java
+++ b/backend/src/main/java/com/ctrl/cbnu_archive/file/dto/FileResponse.java
@@ -1,0 +1,15 @@
+package com.ctrl.cbnu_archive.file.dto;
+
+import com.ctrl.cbnu_archive.file.domain.FileType;
+import java.time.LocalDateTime;
+
+public record FileResponse(
+        Long id,
+        Long projectId,
+        String fileName,
+        FileType fileType,
+        Long size,
+        String downloadUrl,
+        LocalDateTime uploadedAt
+) {
+}

--- a/backend/src/main/java/com/ctrl/cbnu_archive/file/dto/FileUploadResponse.java
+++ b/backend/src/main/java/com/ctrl/cbnu_archive/file/dto/FileUploadResponse.java
@@ -1,0 +1,15 @@
+package com.ctrl.cbnu_archive.file.dto;
+
+import com.ctrl.cbnu_archive.file.domain.FileType;
+import java.time.LocalDateTime;
+
+public record FileUploadResponse(
+        Long id,
+        Long projectId,
+        String fileName,
+        FileType fileType,
+        Long size,
+        String downloadUrl,
+        LocalDateTime uploadedAt
+) {
+}

--- a/backend/src/main/java/com/ctrl/cbnu_archive/file/exception/FileException.java
+++ b/backend/src/main/java/com/ctrl/cbnu_archive/file/exception/FileException.java
@@ -1,0 +1,15 @@
+package com.ctrl.cbnu_archive.file.exception;
+
+import com.ctrl.cbnu_archive.global.exception.CustomException;
+import com.ctrl.cbnu_archive.global.exception.ErrorCode;
+
+public class FileException extends CustomException {
+
+    public FileException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+
+    public FileException(ErrorCode errorCode, String customMessage) {
+        super(errorCode, customMessage);
+    }
+}

--- a/backend/src/main/java/com/ctrl/cbnu_archive/file/repository/ProjectFileRepository.java
+++ b/backend/src/main/java/com/ctrl/cbnu_archive/file/repository/ProjectFileRepository.java
@@ -1,0 +1,11 @@
+package com.ctrl.cbnu_archive.file.repository;
+
+import com.ctrl.cbnu_archive.file.domain.ProjectFile;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ProjectFileRepository extends JpaRepository<ProjectFile, Long> {
+    List<ProjectFile> findByProject_Id(Long projectId);
+}

--- a/backend/src/main/java/com/ctrl/cbnu_archive/file/service/FileService.java
+++ b/backend/src/main/java/com/ctrl/cbnu_archive/file/service/FileService.java
@@ -1,0 +1,139 @@
+package com.ctrl.cbnu_archive.file.service;
+
+import com.ctrl.cbnu_archive.auth.domain.User;
+import com.ctrl.cbnu_archive.auth.repository.UserRepository;
+import com.ctrl.cbnu_archive.file.domain.FileType;
+import com.ctrl.cbnu_archive.file.domain.ProjectFile;
+import com.ctrl.cbnu_archive.file.dto.FileResponse;
+import com.ctrl.cbnu_archive.file.dto.FileUploadResponse;
+import com.ctrl.cbnu_archive.file.exception.FileException;
+import com.ctrl.cbnu_archive.file.repository.ProjectFileRepository;
+import com.ctrl.cbnu_archive.file.service.port.FileStoragePort;
+import com.ctrl.cbnu_archive.global.exception.ErrorCode;
+import com.ctrl.cbnu_archive.project.domain.Project;
+import com.ctrl.cbnu_archive.project.exception.ProjectException;
+import com.ctrl.cbnu_archive.project.repository.ProjectRepository;
+import java.io.IOException;
+import java.time.Duration;
+import java.util.List;
+import java.util.Objects;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+@Service
+@Transactional
+public class FileService {
+
+    private static final Duration DOWNLOAD_URL_TTL = Duration.ofMinutes(15);
+
+    private final ProjectRepository projectRepository;
+    private final UserRepository userRepository;
+    private final ProjectFileRepository fileRepository;
+    private final FileStoragePort fileStoragePort;
+
+    public FileService(
+            ProjectRepository projectRepository,
+            UserRepository userRepository,
+            ProjectFileRepository fileRepository,
+            FileStoragePort fileStoragePort
+    ) {
+        this.projectRepository = projectRepository;
+        this.userRepository = userRepository;
+        this.fileRepository = fileRepository;
+        this.fileStoragePort = fileStoragePort;
+    }
+
+    public FileUploadResponse uploadFile(Long projectId, MultipartFile file, Long currentUserId, boolean isAdmin) {
+        Objects.requireNonNull(projectId, "projectId must not be null");
+        Objects.requireNonNull(file, "file must not be null");
+
+        Project project = validateProjectAccess(projectId, currentUserId, isAdmin);
+        String filename = file.getOriginalFilename();
+        if (filename == null || filename.isBlank()) {
+            throw new FileException(ErrorCode.INVALID_INPUT, "파일 이름이 유효하지 않습니다.");
+        }
+
+        String storageKey = createStorageKey(projectId, filename);
+        try {
+            fileStoragePort.upload(storageKey, file.getInputStream(), file.getSize(), file.getContentType());
+        } catch (IOException e) {
+            throw new FileException(ErrorCode.FILE_UPLOAD_FAILED, "파일 업로드 중 오류가 발생했습니다.");
+        }
+
+        ProjectFile projectFile = ProjectFile.create(filename, FileType.fromContentType(file.getContentType()), file.getSize(), storageKey, project);
+        ProjectFile saved = fileRepository.save(projectFile);
+
+        return toUploadResponse(saved);
+    }
+
+    public FileResponse getFile(Long fileId, Long currentUserId, boolean isAdmin) {
+        Objects.requireNonNull(fileId, "fileId must not be null");
+        ProjectFile projectFile = fileRepository.findById(fileId)
+                .orElseThrow(() -> new FileException(ErrorCode.FILE_NOT_FOUND, "파일을 찾을 수 없습니다."));
+        validateProjectAccess(projectFile.getProjectId(), currentUserId, isAdmin);
+        return toResponse(projectFile);
+    }
+
+    public List<FileResponse> listFilesByProject(Long projectId, Long currentUserId, boolean isAdmin) {
+        Objects.requireNonNull(projectId, "projectId must not be null");
+        validateProjectAccess(projectId, currentUserId, isAdmin);
+        return fileRepository.findByProject_Id(projectId).stream()
+                .map(this::toResponse)
+                .collect(Collectors.toList());
+    }
+
+    public void deleteFile(Long fileId, Long currentUserId, boolean isAdmin) {
+        Objects.requireNonNull(fileId, "fileId must not be null");
+        ProjectFile projectFile = fileRepository.findById(fileId)
+                .orElseThrow(() -> new FileException(ErrorCode.FILE_NOT_FOUND, "파일을 찾을 수 없습니다."));
+        validateProjectAccess(projectFile.getProjectId(), currentUserId, isAdmin);
+        fileStoragePort.delete(projectFile.getStorageKey());
+        fileRepository.delete(projectFile);
+    }
+
+    private Project validateProjectAccess(Long projectId, Long currentUserId, boolean isAdmin) {
+        Project project = projectRepository.findById(projectId)
+                .orElseThrow(() -> new ProjectException(ErrorCode.PROJECT_NOT_FOUND, "프로젝트를 찾을 수 없습니다."));
+        if (isAdmin) {
+            return project;
+        }
+        User currentUser = userRepository.findById(currentUserId)
+                .orElseThrow(() -> new ProjectException(ErrorCode.USER_NOT_FOUND, "사용자를 찾을 수 없습니다."));
+        if (!project.isAuthor(currentUser)) {
+            throw new FileException(ErrorCode.FORBIDDEN, "파일 접근 권한이 없습니다.");
+        }
+        return project;
+    }
+
+    private FileUploadResponse toUploadResponse(ProjectFile projectFile) {
+        return new FileUploadResponse(
+                projectFile.getId(),
+                projectFile.getProjectId(),
+                projectFile.getFileName(),
+                projectFile.getFileType(),
+                projectFile.getSize(),
+                fileStoragePort.generatePresignedUrl(projectFile.getStorageKey(), DOWNLOAD_URL_TTL),
+                projectFile.getUploadedAt()
+        );
+    }
+
+    private FileResponse toResponse(ProjectFile projectFile) {
+        return new FileResponse(
+                projectFile.getId(),
+                projectFile.getProjectId(),
+                projectFile.getFileName(),
+                projectFile.getFileType(),
+                projectFile.getSize(),
+                fileStoragePort.generatePresignedUrl(projectFile.getStorageKey(), DOWNLOAD_URL_TTL),
+                projectFile.getUploadedAt()
+        );
+    }
+
+    private String createStorageKey(Long projectId, String filename) {
+        String sanitizedFilename = filename.replaceAll("[^a-zA-Z0-9._-]", "_");
+        return String.format("projects/%d/%s-%s", projectId, UUID.randomUUID(), sanitizedFilename);
+    }
+}

--- a/backend/src/main/java/com/ctrl/cbnu_archive/file/service/adapter/mock/MockFileStorageAdapter.java
+++ b/backend/src/main/java/com/ctrl/cbnu_archive/file/service/adapter/mock/MockFileStorageAdapter.java
@@ -1,0 +1,58 @@
+package com.ctrl.cbnu_archive.file.service.adapter.mock;
+
+import com.ctrl.cbnu_archive.file.service.port.FileStoragePort;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.time.Duration;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+
+@Component
+@ConditionalOnProperty(prefix = "app.adapter", name = "storage", havingValue = "mock", matchIfMissing = true)
+public class MockFileStorageAdapter implements FileStoragePort {
+
+    private static final Logger log = LoggerFactory.getLogger(MockFileStorageAdapter.class);
+    private final Map<String, byte[]> storage = new ConcurrentHashMap<>();
+
+    @Override
+    public String upload(String path, InputStream is, long size, String contentType) {
+        Objects.requireNonNull(path, "path must not be null");
+        Objects.requireNonNull(is, "input stream must not be null");
+        try {
+            byte[] payload = is.readAllBytes();
+            storage.put(path, payload);
+            log.info("[MOCK] called upload(path={}, size={}, contentType={})", path, size, contentType);
+            return path;
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to read input stream in mock upload", e);
+        }
+    }
+
+    @Override
+    public InputStream download(String storedKey) {
+        log.info("[MOCK] called download(storedKey={})", storedKey);
+        byte[] payload = storage.get(storedKey);
+        if (payload == null) {
+            throw new IllegalArgumentException("Mock file not found: " + storedKey);
+        }
+        return new ByteArrayInputStream(payload);
+    }
+
+    @Override
+    public void delete(String storedKey) {
+        log.info("[MOCK] called delete(storedKey={})", storedKey);
+        storage.remove(storedKey);
+    }
+
+    @Override
+    public String generatePresignedUrl(String storedKey, Duration ttl) {
+        log.info("[MOCK] called generatePresignedUrl(storedKey={}, ttl={})", storedKey, ttl);
+        return String.format("https://mock-storage.local/%s?ttl=%s", storedKey, ttl.toSeconds());
+    }
+}

--- a/backend/src/main/java/com/ctrl/cbnu_archive/file/service/port/FileStoragePort.java
+++ b/backend/src/main/java/com/ctrl/cbnu_archive/file/service/port/FileStoragePort.java
@@ -1,0 +1,11 @@
+package com.ctrl.cbnu_archive.file.service.port;
+
+import java.io.InputStream;
+import java.time.Duration;
+
+public interface FileStoragePort {
+    String upload(String path, InputStream is, long size, String contentType);
+    InputStream download(String storedKey);
+    void delete(String storedKey);
+    String generatePresignedUrl(String storedKey, Duration ttl);
+}

--- a/backend/src/main/java/com/ctrl/cbnu_archive/global/config/AsyncConfig.java
+++ b/backend/src/main/java/com/ctrl/cbnu_archive/global/config/AsyncConfig.java
@@ -1,0 +1,9 @@
+package com.ctrl.cbnu_archive.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+
+@Configuration
+@EnableAsync
+public class AsyncConfig {
+}

--- a/backend/src/main/java/com/ctrl/cbnu_archive/global/config/CorsConfig.java
+++ b/backend/src/main/java/com/ctrl/cbnu_archive/global/config/CorsConfig.java
@@ -1,0 +1,30 @@
+package com.ctrl.cbnu_archive.global.config;
+
+import java.util.List;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+@Configuration
+public class CorsConfig {
+
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource(
+            @Value("${app.cors.allowed-origins}") List<String> allowedOrigins
+    ) {
+        CorsConfiguration configuration = new CorsConfiguration();
+        configuration.setAllowedOrigins(allowedOrigins);
+        configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
+        configuration.setAllowedHeaders(List.of("*"));
+        configuration.setAllowCredentials(true);
+        configuration.setExposedHeaders(List.of("Authorization"));
+        configuration.setMaxAge(3600L);
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", configuration);
+        return source;
+    }
+}

--- a/backend/src/main/java/com/ctrl/cbnu_archive/global/config/SecurityConfig.java
+++ b/backend/src/main/java/com/ctrl/cbnu_archive/global/config/SecurityConfig.java
@@ -1,0 +1,63 @@
+package com.ctrl.cbnu_archive.global.config;
+
+import com.ctrl.cbnu_archive.global.security.jwt.JwtAccessDeniedHandler;
+import com.ctrl.cbnu_archive.global.security.jwt.JwtAuthenticationEntryPoint;
+import com.ctrl.cbnu_archive.global.security.jwt.JwtAuthenticationFilter;
+import com.ctrl.cbnu_archive.global.security.jwt.JwtTokenProvider;
+import org.springframework.context.annotation.Bean;
+import org.springframework.http.HttpMethod;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfigurationSource;
+
+@Configuration
+@EnableMethodSecurity
+public class SecurityConfig {
+
+    private final JwtTokenProvider jwtTokenProvider;
+
+    public SecurityConfig(JwtTokenProvider jwtTokenProvider) {
+        this.jwtTokenProvider = jwtTokenProvider;
+    }
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http, CorsConfigurationSource corsConfigurationSource) throws Exception {
+        http.csrf(csrf -> csrf.disable())
+                .cors(cors -> cors.configurationSource(corsConfigurationSource))
+                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .exceptionHandling(exception -> exception
+                        .authenticationEntryPoint(new JwtAuthenticationEntryPoint())
+                        .accessDeniedHandler(new JwtAccessDeniedHandler())
+                )
+                .authorizeHttpRequests(authorize -> authorize
+                        .requestMatchers("/api/v1/auth/**", "/swagger-ui/**", "/v3/api-docs/**", "/swagger-ui.html", "/h2-console/**").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/api/v1/projects/**").permitAll()
+                        .requestMatchers(HttpMethod.POST, "/api/v1/projects/recommend").permitAll()
+                        .requestMatchers("/api/v1/files/**").authenticated()
+                        .requestMatchers("/api/v1/projects/**").authenticated()
+                        .anyRequest().authenticated()
+                )
+                .headers(headers -> headers.frameOptions(frame -> frame.disable()));
+
+        http.addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider), UsernamePasswordAuthenticationFilter.class);
+        return http.build();
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public AuthenticationManager authenticationManager(AuthenticationConfiguration configuration) throws Exception {
+        return configuration.getAuthenticationManager();
+    }
+}

--- a/backend/src/main/java/com/ctrl/cbnu_archive/global/config/SwaggerConfig.java
+++ b/backend/src/main/java/com/ctrl/cbnu_archive/global/config/SwaggerConfig.java
@@ -1,0 +1,30 @@
+package com.ctrl.cbnu_archive.global.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+
+    @Bean
+    public OpenAPI cbnuArchiveOpenApi() {
+        final String securitySchemeName = "bearerAuth";
+
+        return new OpenAPI()
+                .info(new Info().title("CBNU Archive API").version("v1"))
+                .components(new Components().addSecuritySchemes(securitySchemeName,
+                        new SecurityScheme()
+                                .type(SecurityScheme.Type.HTTP)
+                                .scheme("bearer")
+                                .bearerFormat("JWT")
+                                .in(SecurityScheme.In.HEADER)
+                                .name("Authorization")
+                ))
+                .addSecurityItem(new SecurityRequirement().addList(securitySchemeName));
+    }
+}

--- a/backend/src/main/java/com/ctrl/cbnu_archive/global/domain/BaseTimeEntity.java
+++ b/backend/src/main/java/com/ctrl/cbnu_archive/global/domain/BaseTimeEntity.java
@@ -1,0 +1,25 @@
+package com.ctrl.cbnu_archive.global.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseTimeEntity {
+
+    @CreatedDate
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+}

--- a/backend/src/main/java/com/ctrl/cbnu_archive/global/exception/CustomException.java
+++ b/backend/src/main/java/com/ctrl/cbnu_archive/global/exception/CustomException.java
@@ -1,0 +1,20 @@
+package com.ctrl.cbnu_archive.global.exception;
+
+public class CustomException extends RuntimeException {
+
+    private final ErrorCode errorCode;
+
+    public CustomException(ErrorCode errorCode) {
+        super(errorCode.message());
+        this.errorCode = errorCode;
+    }
+
+    public CustomException(ErrorCode errorCode, String customMessage) {
+        super(customMessage);
+        this.errorCode = errorCode;
+    }
+
+    public ErrorCode getErrorCode() {
+        return errorCode;
+    }
+}

--- a/backend/src/main/java/com/ctrl/cbnu_archive/global/exception/ErrorCode.java
+++ b/backend/src/main/java/com/ctrl/cbnu_archive/global/exception/ErrorCode.java
@@ -1,0 +1,42 @@
+package com.ctrl.cbnu_archive.global.exception;
+
+import org.springframework.http.HttpStatus;
+
+public enum ErrorCode {
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "C001", "서버 내부 오류"),
+    INVALID_INPUT(HttpStatus.BAD_REQUEST, "C002", "잘못된 입력값입니다"),
+    METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED, "C003", "허용되지 않는 메서드"),
+    ENTITY_NOT_FOUND(HttpStatus.NOT_FOUND, "C004", "엔티티를 찾을 수 없습니다"),
+    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "A001", "인증이 필요합니다"),
+    FORBIDDEN(HttpStatus.FORBIDDEN, "A002", "접근 권한이 없습니다"),
+    INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "A003", "유효하지 않은 토큰"),
+    EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "A004", "만료된 토큰"),
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "U001", "사용자를 찾을 수 없습니다"),
+    DUPLICATE_EMAIL(HttpStatus.CONFLICT, "U002", "이미 존재하는 이메일"),
+    PROJECT_NOT_FOUND(HttpStatus.NOT_FOUND, "P001", "프로젝트를 찾을 수 없습니다"),
+    NOT_PROJECT_OWNER(HttpStatus.FORBIDDEN, "P002", "프로젝트 작성자만 수정/삭제할 수 있습니다"),
+    FILE_UPLOAD_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "F001", "파일 업로드 실패"),
+    FILE_NOT_FOUND(HttpStatus.NOT_FOUND, "F002", "파일을 찾을 수 없습니다");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+
+    ErrorCode(HttpStatus status, String code, String message) {
+        this.status = status;
+        this.code = code;
+        this.message = message;
+    }
+
+    public HttpStatus status() {
+        return status;
+    }
+
+    public String code() {
+        return code;
+    }
+
+    public String message() {
+        return message;
+    }
+}

--- a/backend/src/main/java/com/ctrl/cbnu_archive/global/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/ctrl/cbnu_archive/global/exception/GlobalExceptionHandler.java
@@ -1,0 +1,57 @@
+package com.ctrl.cbnu_archive.global.exception;
+
+import com.ctrl.cbnu_archive.global.response.ApiResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.FieldError;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.security.access.AccessDeniedException;
+import java.util.stream.Collectors;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    private static final Logger log = LoggerFactory.getLogger(GlobalExceptionHandler.class);
+
+    @ExceptionHandler(CustomException.class)
+    public ResponseEntity<ApiResponse<Void>> handleCustomException(CustomException ex) {
+        ErrorCode errorCode = ex.getErrorCode();
+        ApiResponse<Void> response = ApiResponse.error(errorCode, ex.getMessage());
+        return ResponseEntity.status(errorCode.status()).body(response);
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ApiResponse<Void>> handleValidationException(MethodArgumentNotValidException ex) {
+        BindingResult bindingResult = ex.getBindingResult();
+        String message = bindingResult.getFieldErrors().stream()
+                .map(FieldError::getDefaultMessage)
+                .collect(Collectors.joining("; "));
+        ApiResponse<Void> response = ApiResponse.error(ErrorCode.INVALID_INPUT, message.isBlank() ? ErrorCode.INVALID_INPUT.message() : message);
+        return ResponseEntity.status(ErrorCode.INVALID_INPUT.status()).body(response);
+    }
+
+    @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
+    public ResponseEntity<ApiResponse<Void>> handleMethodNotAllowed(HttpRequestMethodNotSupportedException ex) {
+        ApiResponse<Void> response = ApiResponse.error(ErrorCode.METHOD_NOT_ALLOWED, ex.getMessage());
+        return ResponseEntity.status(ErrorCode.METHOD_NOT_ALLOWED.status()).body(response);
+    }
+
+    @ExceptionHandler(AccessDeniedException.class)
+    public ResponseEntity<ApiResponse<Void>> handleAccessDenied(AccessDeniedException ex) {
+        ApiResponse<Void> response = ApiResponse.error(ErrorCode.FORBIDDEN, ex.getMessage());
+        return ResponseEntity.status(ErrorCode.FORBIDDEN.status()).body(response);
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ApiResponse<Void>> handleGenericException(Exception ex, HttpServletRequest request) {
+        log.error("Unhandled exception caught at {} {}", request.getMethod(), request.getRequestURI(), ex);
+        ApiResponse<Void> response = ApiResponse.error(ErrorCode.INTERNAL_SERVER_ERROR, ErrorCode.INTERNAL_SERVER_ERROR.message());
+        return ResponseEntity.status(ErrorCode.INTERNAL_SERVER_ERROR.status()).body(response);
+    }
+}

--- a/backend/src/main/java/com/ctrl/cbnu_archive/global/response/ApiResponse.java
+++ b/backend/src/main/java/com/ctrl/cbnu_archive/global/response/ApiResponse.java
@@ -1,0 +1,22 @@
+package com.ctrl.cbnu_archive.global.response;
+
+import com.ctrl.cbnu_archive.global.exception.ErrorCode;
+
+public record ApiResponse<T>(boolean success, String message, T data, String errorCode) {
+
+    public static <T> ApiResponse<T> success(T data) {
+        return new ApiResponse<>(true, "OK", data, null);
+    }
+
+    public static <T> ApiResponse<T> success(String message, T data) {
+        return new ApiResponse<>(true, message, data, null);
+    }
+
+    public static <T> ApiResponse<T> error(ErrorCode errorCode) {
+        return new ApiResponse<>(false, errorCode.message(), null, errorCode.code());
+    }
+
+    public static <T> ApiResponse<T> error(ErrorCode errorCode, String customMessage) {
+        return new ApiResponse<>(false, customMessage, null, errorCode.code());
+    }
+}

--- a/backend/src/main/java/com/ctrl/cbnu_archive/global/security/jwt/CustomUserDetails.java
+++ b/backend/src/main/java/com/ctrl/cbnu_archive/global/security/jwt/CustomUserDetails.java
@@ -1,0 +1,70 @@
+package com.ctrl.cbnu_archive.global.security.jwt;
+
+import com.ctrl.cbnu_archive.auth.domain.UserRole;
+import java.util.Collection;
+import java.util.List;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+public class CustomUserDetails implements UserDetails {
+
+    private final Long id;
+    private final String username;
+    private final String password;
+    private final UserRole role;
+
+    public CustomUserDetails(Long id, String username, String password, UserRole role) {
+        this.id = id;
+        this.username = username;
+        this.password = password;
+        this.role = role;
+    }
+
+    public static CustomUserDetails fromToken(Long id, String email, UserRole role) {
+        return new CustomUserDetails(id, email, "", role);
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return List.of(new SimpleGrantedAuthority("ROLE_" + role.name()));
+    }
+
+    @Override
+    public String getPassword() {
+        return password;
+    }
+
+    @Override
+    public String getUsername() {
+        return username;
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public UserRole getRole() {
+        return role;
+    }
+}

--- a/backend/src/main/java/com/ctrl/cbnu_archive/global/security/jwt/CustomUserDetailsService.java
+++ b/backend/src/main/java/com/ctrl/cbnu_archive/global/security/jwt/CustomUserDetailsService.java
@@ -1,0 +1,28 @@
+package com.ctrl.cbnu_archive.global.security.jwt;
+
+import com.ctrl.cbnu_archive.auth.domain.User;
+import com.ctrl.cbnu_archive.auth.repository.UserRepository;
+import jakarta.transaction.Transactional;
+import java.util.Optional;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+@Service
+@Transactional
+public class CustomUserDetailsService implements UserDetailsService {
+
+    private final UserRepository userRepository;
+
+    public CustomUserDetailsService(UserRepository userRepository) {
+        this.userRepository = userRepository;
+    }
+
+    @Override
+    public UserDetails loadUserByUsername(String email) {
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new UsernameNotFoundException("User not found: " + email));
+        return new CustomUserDetails(user.getId(), user.getEmail(), user.getPassword(), user.getRole());
+    }
+}

--- a/backend/src/main/java/com/ctrl/cbnu_archive/global/security/jwt/JwtAccessDeniedHandler.java
+++ b/backend/src/main/java/com/ctrl/cbnu_archive/global/security/jwt/JwtAccessDeniedHandler.java
@@ -1,0 +1,29 @@
+package com.ctrl.cbnu_archive.global.security.jwt;
+
+import com.ctrl.cbnu_archive.global.exception.ErrorCode;
+import com.ctrl.cbnu_archive.global.response.ApiResponse;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import org.springframework.http.MediaType;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+
+public class JwtAccessDeniedHandler implements AccessDeniedHandler {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Override
+    public void handle(HttpServletRequest request,
+                       HttpServletResponse response,
+                       AccessDeniedException accessDeniedException) throws IOException, ServletException {
+        response.setStatus(ErrorCode.FORBIDDEN.status().value());
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding(StandardCharsets.UTF_8.name());
+        var body = ApiResponse.<Void>error(ErrorCode.FORBIDDEN, accessDeniedException.getMessage());
+        response.getWriter().write(objectMapper.writeValueAsString(body));
+    }
+}

--- a/backend/src/main/java/com/ctrl/cbnu_archive/global/security/jwt/JwtAuthenticationEntryPoint.java
+++ b/backend/src/main/java/com/ctrl/cbnu_archive/global/security/jwt/JwtAuthenticationEntryPoint.java
@@ -1,0 +1,28 @@
+package com.ctrl.cbnu_archive.global.security.jwt;
+
+import com.ctrl.cbnu_archive.global.exception.ErrorCode;
+import com.ctrl.cbnu_archive.global.response.ApiResponse;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+
+public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException)
+            throws IOException, ServletException {
+        response.setStatus(ErrorCode.UNAUTHORIZED.status().value());
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding(StandardCharsets.UTF_8.name());
+        var body = ApiResponse.<Void>error(ErrorCode.UNAUTHORIZED, authException.getMessage());
+        response.getWriter().write(objectMapper.writeValueAsString(body));
+    }
+}

--- a/backend/src/main/java/com/ctrl/cbnu_archive/global/security/jwt/JwtAuthenticationFilter.java
+++ b/backend/src/main/java/com/ctrl/cbnu_archive/global/security/jwt/JwtAuthenticationFilter.java
@@ -1,0 +1,53 @@
+package com.ctrl.cbnu_archive.global.security.jwt;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private static final Logger log = LoggerFactory.getLogger(JwtAuthenticationFilter.class);
+
+    private final JwtTokenProvider jwtTokenProvider;
+
+    public JwtAuthenticationFilter(JwtTokenProvider jwtTokenProvider) {
+        this.jwtTokenProvider = jwtTokenProvider;
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain filterChain) throws ServletException, IOException {
+        String token = resolveToken(request);
+        if (StringUtils.hasText(token) && jwtTokenProvider.validateToken(token)) {
+            Long userId = jwtTokenProvider.getUserIdFromToken(token);
+            String email = jwtTokenProvider.getEmailFromToken(token);
+            var role = jwtTokenProvider.getRoleFromToken(token);
+
+            var principal = CustomUserDetails.fromToken(userId, email, role);
+            var authentication = new UsernamePasswordAuthenticationToken(principal, null, principal.getAuthorities());
+            authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+        } else if (StringUtils.hasText(token)) {
+            log.debug("Invalid JWT token received");
+        }
+        filterChain.doFilter(request, response);
+    }
+
+    private String resolveToken(HttpServletRequest request) {
+        String bearerToken = request.getHeader("Authorization");
+        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith("Bearer ")) {
+            return bearerToken.substring(7);
+        }
+        return null;
+    }
+}

--- a/backend/src/main/java/com/ctrl/cbnu_archive/global/security/jwt/JwtTokenProvider.java
+++ b/backend/src/main/java/com/ctrl/cbnu_archive/global/security/jwt/JwtTokenProvider.java
@@ -1,0 +1,97 @@
+package com.ctrl.cbnu_archive.global.security.jwt;
+
+import com.ctrl.cbnu_archive.auth.domain.UserRole;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.Jws;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.Keys;
+import io.jsonwebtoken.security.SignatureException;
+import java.nio.charset.StandardCharsets;
+import java.security.Key;
+import java.util.Base64;
+import java.util.Date;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+public class JwtTokenProvider {
+
+    private static final String CLAIM_EMAIL = "email";
+    private static final String CLAIM_ROLE = "role";
+
+    private final Key key;
+    private final long accessTokenExpiryMs;
+    private final long refreshTokenExpiryMs;
+
+    public JwtTokenProvider(
+            @Value("${jwt.secret}") String secret,
+            @Value("${jwt.access-token-expiry}") long accessTokenExpiryMs,
+            @Value("${jwt.refresh-token-expiry}") long refreshTokenExpiryMs
+    ) {
+        this.key = Keys.hmacShaKeyFor(Base64.getDecoder().decode(secret));
+        this.accessTokenExpiryMs = accessTokenExpiryMs;
+        this.refreshTokenExpiryMs = refreshTokenExpiryMs;
+    }
+
+    public String generateAccessToken(Long userId, String email, UserRole role) {
+        Date now = new Date();
+        Date expiry = new Date(now.getTime() + accessTokenExpiryMs);
+
+        return Jwts.builder()
+                .setSubject(String.valueOf(userId))
+                .claim(CLAIM_EMAIL, email)
+                .claim(CLAIM_ROLE, role.name())
+                .setIssuedAt(now)
+                .setExpiration(expiry)
+                .signWith(key, SignatureAlgorithm.HS256)
+                .compact();
+    }
+
+    public String generateRefreshToken(Long userId) {
+        Date now = new Date();
+        Date expiry = new Date(now.getTime() + refreshTokenExpiryMs);
+
+        return Jwts.builder()
+                .setSubject(String.valueOf(userId))
+                .setIssuedAt(now)
+                .setExpiration(expiry)
+                .signWith(key, SignatureAlgorithm.HS256)
+                .compact();
+    }
+
+    public boolean validateToken(String token) {
+        try {
+            Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token);
+            return true;
+        } catch (ExpiredJwtException | MalformedJwtException | SignatureException | IllegalArgumentException ex) {
+            return false;
+        }
+    }
+
+    public Long getUserIdFromToken(String token) {
+        Claims claims = parseClaims(token);
+        return Long.valueOf(claims.getSubject());
+    }
+
+    public String getEmailFromToken(String token) {
+        Claims claims = parseClaims(token);
+        return claims.get(CLAIM_EMAIL, String.class);
+    }
+
+    public UserRole getRoleFromToken(String token) {
+        Claims claims = parseClaims(token);
+        String roleName = claims.get(CLAIM_ROLE, String.class);
+        return UserRole.valueOf(roleName);
+    }
+
+    private Claims parseClaims(String token) {
+        return Jwts.parserBuilder()
+                .setSigningKey(key)
+                .build()
+                .parseClaimsJws(token)
+                .getBody();
+    }
+}

--- a/backend/src/main/java/com/ctrl/cbnu_archive/project/controller/ProjectController.java
+++ b/backend/src/main/java/com/ctrl/cbnu_archive/project/controller/ProjectController.java
@@ -1,0 +1,84 @@
+package com.ctrl.cbnu_archive.project.controller;
+
+import com.ctrl.cbnu_archive.global.response.ApiResponse;
+import com.ctrl.cbnu_archive.global.security.jwt.CustomUserDetails;
+import com.ctrl.cbnu_archive.project.dto.AiRecommendResponse;
+import com.ctrl.cbnu_archive.project.dto.ProjectCreateRequest;
+import com.ctrl.cbnu_archive.project.dto.ProjectResponse;
+import com.ctrl.cbnu_archive.project.dto.ProjectUpdateRequest;
+import com.ctrl.cbnu_archive.project.dto.RecommendRequest;
+import com.ctrl.cbnu_archive.project.dto.SearchRequest;
+import com.ctrl.cbnu_archive.project.service.ProjectService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.data.domain.Page;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/projects")
+@Tag(name = "Project", description = "프로젝트 API")
+public class ProjectController {
+
+    private final ProjectService projectService;
+
+    public ProjectController(ProjectService projectService) {
+        this.projectService = projectService;
+    }
+
+    @Operation(summary = "프로젝트 등록", description = "인증된 사용자가 새 프로젝트를 등록합니다.")
+    @PostMapping
+    public ApiResponse<ProjectResponse> createProject(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @Valid @RequestBody ProjectCreateRequest request
+    ) {
+        return ApiResponse.success(projectService.createProject(request, userDetails.getId()));
+    }
+
+    @Operation(summary = "프로젝트 상세 조회", description = "프로젝트 상세 정보를 조회합니다.")
+    @GetMapping("/{id}")
+    public ApiResponse<ProjectResponse> getProject(@PathVariable Long id) {
+        return ApiResponse.success(projectService.getProject(id));
+    }
+
+    @Operation(summary = "프로젝트 검색", description = "검색 조건으로 프로젝트 목록을 조회합니다.")
+    @GetMapping
+    public ApiResponse<Page<ProjectResponse>> searchProjects(@ModelAttribute SearchRequest request) {
+        return ApiResponse.success(projectService.searchProjects(request));
+    }
+
+    @Operation(summary = "프로젝트 수정", description = "프로젝트 작성자 또는 ADMIN이 프로젝트를 수정합니다.")
+    @PatchMapping("/{id}")
+    public ApiResponse<ProjectResponse> updateProject(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @PathVariable Long id,
+            @Valid @RequestBody ProjectUpdateRequest request
+    ) {
+        return ApiResponse.success(projectService.updateProject(id, request, userDetails.getId(), userDetails.getAuthorities().stream().anyMatch(auth -> auth.getAuthority().equals("ROLE_ADMIN"))));
+    }
+
+    @Operation(summary = "프로젝트 삭제", description = "프로젝트 작성자 또는 ADMIN이 프로젝트를 삭제합니다.")
+    @DeleteMapping("/{id}")
+    public ApiResponse<Void> deleteProject(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @PathVariable Long id
+    ) {
+        projectService.deleteProject(id, userDetails.getId(), userDetails.getAuthorities().stream().anyMatch(auth -> auth.getAuthority().equals("ROLE_ADMIN")));
+        return ApiResponse.success(null);
+    }
+
+    @Operation(summary = "AI 추천", description = "자연어 질의를 통해 프로젝트 추천을 제공합니다.")
+    @PostMapping("/recommend")
+    public ApiResponse<AiRecommendResponse> recommendProjects(@Valid @RequestBody RecommendRequest request) {
+        return ApiResponse.success(projectService.recommendByQuery(request.query()));
+    }
+}

--- a/backend/src/main/java/com/ctrl/cbnu_archive/project/domain/Project.java
+++ b/backend/src/main/java/com/ctrl/cbnu_archive/project/domain/Project.java
@@ -1,0 +1,170 @@
+package com.ctrl.cbnu_archive.project.domain;
+
+import com.ctrl.cbnu_archive.auth.domain.User;
+import com.ctrl.cbnu_archive.global.domain.BaseTimeEntity;
+import jakarta.persistence.CollectionTable;
+import jakarta.persistence.Column;
+import jakarta.persistence.ElementCollection;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.Lob;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+@Entity
+@Table(name = "projects")
+public class Project extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String title;
+
+    @Lob
+    private String summary;
+
+    @Lob
+    private String description;
+
+    @Lob
+    private String readme;
+
+    @ElementCollection
+    @CollectionTable(name = "project_tech_stack", joinColumns = @JoinColumn(name = "project_id"))
+    @Column(name = "tech_stack")
+    private List<String> techStacks = new ArrayList<>();
+
+    private Integer year;
+    private String semester;
+    private String difficulty;
+    private String domain;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "author_id", nullable = false)
+    private User author;
+
+    protected Project() {
+        // JPA requires a default constructor
+    }
+
+    private Project(String title,
+                    String summary,
+                    String description,
+                    String readme,
+                    List<String> techStacks,
+                    Integer year,
+                    String semester,
+                    String difficulty,
+                    String domain,
+                    User author) {
+        this.title = Objects.requireNonNull(title, "title must not be null");
+        this.summary = summary;
+        this.description = description;
+        this.readme = readme;
+        if (techStacks != null) {
+            this.techStacks = new ArrayList<>(techStacks);
+        }
+        this.year = year;
+        this.semester = semester;
+        this.difficulty = difficulty;
+        this.domain = domain;
+        this.author = Objects.requireNonNull(author, "author must not be null");
+    }
+
+    public static Project create(String title,
+                                 String summary,
+                                 String description,
+                                 String readme,
+                                 List<String> techStacks,
+                                 Integer year,
+                                 String semester,
+                                 String difficulty,
+                                 String domain,
+                                 User author) {
+        return new Project(title, summary, description, readme, techStacks, year, semester, difficulty, domain, author);
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public String getSummary() {
+        return summary;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public String getReadme() {
+        return readme;
+    }
+
+    public List<String> getTechStacks() {
+        return List.copyOf(techStacks);
+    }
+
+    public Integer getYear() {
+        return year;
+    }
+
+    public String getSemester() {
+        return semester;
+    }
+
+    public String getDifficulty() {
+        return difficulty;
+    }
+
+    public String getDomain() {
+        return domain;
+    }
+
+    public Long getAuthorId() {
+        return author.getId();
+    }
+
+    public String getAuthorName() {
+        return author.getName();
+    }
+
+    public boolean isAuthor(User user) {
+        return user != null && author != null && user.getId().equals(author.getId());
+    }
+
+    public void updateSummary(String summary) {
+        this.summary = summary;
+    }
+
+    public void updateDetails(String title,
+                              String description,
+                              String readme,
+                              List<String> techStacks,
+                              Integer year,
+                              String semester,
+                              String difficulty,
+                              String domain) {
+        this.title = Objects.requireNonNull(title, "title must not be null");
+        this.description = description;
+        this.readme = readme;
+        this.techStacks = techStacks == null ? new ArrayList<>() : new ArrayList<>(techStacks);
+        this.year = year;
+        this.semester = semester;
+        this.difficulty = difficulty;
+        this.domain = domain;
+    }
+
+}

--- a/backend/src/main/java/com/ctrl/cbnu_archive/project/dto/AiRecommendResponse.java
+++ b/backend/src/main/java/com/ctrl/cbnu_archive/project/dto/AiRecommendResponse.java
@@ -1,0 +1,10 @@
+package com.ctrl.cbnu_archive.project.dto;
+
+import java.util.List;
+
+public record AiRecommendResponse(
+        String answer,
+        List<Long> recommendedProjectIds,
+        String reasoning
+) {
+}

--- a/backend/src/main/java/com/ctrl/cbnu_archive/project/dto/ProjectCreateRequest.java
+++ b/backend/src/main/java/com/ctrl/cbnu_archive/project/dto/ProjectCreateRequest.java
@@ -1,0 +1,31 @@
+package com.ctrl.cbnu_archive.project.dto;
+
+import com.ctrl.cbnu_archive.auth.domain.User;
+import com.ctrl.cbnu_archive.project.domain.Project;
+import java.util.List;
+
+public record ProjectCreateRequest(
+        String title,
+        String description,
+        String readme,
+        List<String> techStacks,
+        Integer year,
+        String semester,
+        String difficulty,
+        String domain
+) {
+    public Project toEntity(User author) {
+        return Project.create(
+                title,
+                null,
+                description,
+                readme,
+                techStacks,
+                year,
+                semester,
+                difficulty,
+                domain,
+                author
+        );
+    }
+}

--- a/backend/src/main/java/com/ctrl/cbnu_archive/project/dto/ProjectResponse.java
+++ b/backend/src/main/java/com/ctrl/cbnu_archive/project/dto/ProjectResponse.java
@@ -1,0 +1,61 @@
+package com.ctrl.cbnu_archive.project.dto;
+
+import com.ctrl.cbnu_archive.project.domain.Project;
+import com.ctrl.cbnu_archive.project.service.port.ProjectSearchResult;
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record ProjectResponse(
+        Long id,
+        String title,
+        String summary,
+        String description,
+        String readme,
+        List<String> techStacks,
+        Integer year,
+        String semester,
+        String difficulty,
+        String domain,
+        Long authorId,
+        String authorName,
+        LocalDateTime createdAt,
+        LocalDateTime updatedAt
+) {
+    public static ProjectResponse fromEntity(Project project) {
+        return new ProjectResponse(
+                project.getId(),
+                project.getTitle(),
+                project.getSummary(),
+                project.getDescription(),
+                project.getReadme(),
+                project.getTechStacks(),
+                project.getYear(),
+                project.getSemester(),
+                project.getDifficulty(),
+                project.getDomain(),
+                project.getAuthorId(),
+                project.getAuthorName(),
+                project.getCreatedAt(),
+                project.getUpdatedAt()
+        );
+    }
+
+    public static ProjectResponse fromSearchResult(ProjectSearchResult result) {
+        return new ProjectResponse(
+                result.projectId(),
+                result.title(),
+                result.summary(),
+                null,
+                null,
+                result.techStacks(),
+                result.year(),
+                result.semester(),
+                result.difficulty(),
+                null,
+                null,
+                null,
+                null,
+                null
+        );
+    }
+}

--- a/backend/src/main/java/com/ctrl/cbnu_archive/project/dto/ProjectUpdateRequest.java
+++ b/backend/src/main/java/com/ctrl/cbnu_archive/project/dto/ProjectUpdateRequest.java
@@ -1,0 +1,28 @@
+package com.ctrl.cbnu_archive.project.dto;
+
+import com.ctrl.cbnu_archive.project.domain.Project;
+import java.util.List;
+
+public record ProjectUpdateRequest(
+        String title,
+        String description,
+        String readme,
+        List<String> techStacks,
+        Integer year,
+        String semester,
+        String difficulty,
+        String domain
+) {
+    public void applyTo(Project project) {
+        project.updateDetails(
+                title == null ? project.getTitle() : title,
+                description == null ? project.getDescription() : description,
+                readme == null ? project.getReadme() : readme,
+                techStacks == null ? project.getTechStacks() : techStacks,
+                year == null ? project.getYear() : year,
+                semester == null ? project.getSemester() : semester,
+                difficulty == null ? project.getDifficulty() : difficulty,
+                domain == null ? project.getDomain() : domain
+        );
+    }
+}

--- a/backend/src/main/java/com/ctrl/cbnu_archive/project/dto/RecommendRequest.java
+++ b/backend/src/main/java/com/ctrl/cbnu_archive/project/dto/RecommendRequest.java
@@ -1,0 +1,9 @@
+package com.ctrl.cbnu_archive.project.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record RecommendRequest(
+        @NotBlank(message = "질문은 필수입니다")
+        String query
+) {
+}

--- a/backend/src/main/java/com/ctrl/cbnu_archive/project/dto/SearchRequest.java
+++ b/backend/src/main/java/com/ctrl/cbnu_archive/project/dto/SearchRequest.java
@@ -1,0 +1,18 @@
+package com.ctrl.cbnu_archive.project.dto;
+
+import com.ctrl.cbnu_archive.project.service.port.SearchQuery;
+import java.util.List;
+
+public record SearchRequest(
+        String keyword,
+        List<String> techStacks,
+        Integer year,
+        String semester,
+        String difficulty,
+        int page,
+        int size
+) {
+    public SearchQuery toSearchQuery() {
+        return new SearchQuery(keyword, techStacks, year, semester, difficulty, page, size);
+    }
+}

--- a/backend/src/main/java/com/ctrl/cbnu_archive/project/exception/ProjectException.java
+++ b/backend/src/main/java/com/ctrl/cbnu_archive/project/exception/ProjectException.java
@@ -1,0 +1,15 @@
+package com.ctrl.cbnu_archive.project.exception;
+
+import com.ctrl.cbnu_archive.global.exception.CustomException;
+import com.ctrl.cbnu_archive.global.exception.ErrorCode;
+
+public class ProjectException extends CustomException {
+
+    public ProjectException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+
+    public ProjectException(ErrorCode errorCode, String customMessage) {
+        super(errorCode, customMessage);
+    }
+}

--- a/backend/src/main/java/com/ctrl/cbnu_archive/project/mapper/ProjectMapper.java
+++ b/backend/src/main/java/com/ctrl/cbnu_archive/project/mapper/ProjectMapper.java
@@ -1,0 +1,31 @@
+package com.ctrl.cbnu_archive.project.mapper;
+
+import com.ctrl.cbnu_archive.auth.domain.User;
+import com.ctrl.cbnu_archive.project.domain.Project;
+import com.ctrl.cbnu_archive.project.dto.ProjectCreateRequest;
+import com.ctrl.cbnu_archive.project.dto.ProjectResponse;
+import com.ctrl.cbnu_archive.project.dto.ProjectUpdateRequest;
+import com.ctrl.cbnu_archive.project.service.port.ProjectSearchResult;
+
+public class ProjectMapper {
+
+    private ProjectMapper() {
+        throw new UnsupportedOperationException("ProjectMapper is a utility class");
+    }
+
+    public static Project toEntity(ProjectCreateRequest request, User author) {
+        return request.toEntity(author);
+    }
+
+    public static ProjectResponse toResponse(Project project) {
+        return ProjectResponse.fromEntity(project);
+    }
+
+    public static ProjectResponse toResponse(ProjectSearchResult searchResult) {
+        return ProjectResponse.fromSearchResult(searchResult);
+    }
+
+    public static void applyUpdate(ProjectUpdateRequest request, Project project) {
+        request.applyTo(project);
+    }
+}

--- a/backend/src/main/java/com/ctrl/cbnu_archive/project/repository/ProjectRepository.java
+++ b/backend/src/main/java/com/ctrl/cbnu_archive/project/repository/ProjectRepository.java
@@ -1,0 +1,12 @@
+package com.ctrl.cbnu_archive.project.repository;
+
+import com.ctrl.cbnu_archive.project.domain.Project;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ProjectRepository extends JpaRepository<Project, Long> {
+    Page<Project> findByAuthorId(Long authorId, Pageable pageable);
+}

--- a/backend/src/main/java/com/ctrl/cbnu_archive/project/service/ProjectService.java
+++ b/backend/src/main/java/com/ctrl/cbnu_archive/project/service/ProjectService.java
@@ -1,0 +1,184 @@
+package com.ctrl.cbnu_archive.project.service;
+
+import com.ctrl.cbnu_archive.auth.domain.User;
+import com.ctrl.cbnu_archive.auth.repository.UserRepository;
+import com.ctrl.cbnu_archive.project.domain.Project;
+import com.ctrl.cbnu_archive.project.dto.AiRecommendResponse;
+import com.ctrl.cbnu_archive.project.dto.ProjectCreateRequest;
+import com.ctrl.cbnu_archive.project.dto.ProjectResponse;
+import com.ctrl.cbnu_archive.project.dto.ProjectUpdateRequest;
+import com.ctrl.cbnu_archive.project.dto.SearchRequest;
+import com.ctrl.cbnu_archive.project.mapper.ProjectMapper;
+import com.ctrl.cbnu_archive.project.repository.ProjectRepository;
+import com.ctrl.cbnu_archive.project.service.event.ProjectDeleteEvent;
+import com.ctrl.cbnu_archive.project.service.event.ProjectIndexEvent;
+import com.ctrl.cbnu_archive.global.exception.ErrorCode;
+import com.ctrl.cbnu_archive.project.exception.ProjectException;
+import com.ctrl.cbnu_archive.project.service.exception.ProjectNotFoundException;
+import com.ctrl.cbnu_archive.project.service.port.AiRecommendationPort;
+import com.ctrl.cbnu_archive.project.service.port.AiSummaryPort;
+import com.ctrl.cbnu_archive.project.service.port.ProjectSearchResult;
+import com.ctrl.cbnu_archive.project.service.port.EmbeddingPort;
+import com.ctrl.cbnu_archive.project.service.port.ProjectContext;
+import com.ctrl.cbnu_archive.project.service.port.ProjectIndexDocument;
+import com.ctrl.cbnu_archive.project.service.port.ProjectSearchPort;
+import com.ctrl.cbnu_archive.project.service.port.VectorMatch;
+import com.ctrl.cbnu_archive.project.service.port.VectorSearchPort;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+public class ProjectService {
+
+    private final ProjectRepository repository;
+    private final UserRepository userRepository;
+    private final ProjectSearchPort searchPort;
+    private final VectorSearchPort vectorPort;
+    private final EmbeddingPort embeddingPort;
+    private final AiSummaryPort aiSummaryPort;
+    private final AiRecommendationPort aiRecommendationPort;
+    private final ApplicationEventPublisher eventPublisher;
+
+    public ProjectService(
+            ProjectRepository repository,
+            UserRepository userRepository,
+            ProjectSearchPort searchPort,
+            VectorSearchPort vectorPort,
+            EmbeddingPort embeddingPort,
+            AiSummaryPort aiSummaryPort,
+            AiRecommendationPort aiRecommendationPort,
+            ApplicationEventPublisher eventPublisher
+    ) {
+        this.repository = repository;
+        this.userRepository = userRepository;
+        this.searchPort = searchPort;
+        this.vectorPort = vectorPort;
+        this.embeddingPort = embeddingPort;
+        this.aiSummaryPort = aiSummaryPort;
+        this.aiRecommendationPort = aiRecommendationPort;
+        this.eventPublisher = eventPublisher;
+    }
+
+    public ProjectResponse createProject(ProjectCreateRequest request, Long authorId) {
+        Objects.requireNonNull(request, "ProjectCreateRequest must not be null");
+        Objects.requireNonNull(authorId, "authorId must not be null");
+        User author = userRepository.findById(authorId)
+                .orElseThrow(() -> new ProjectException(ErrorCode.USER_NOT_FOUND, "사용자를 찾을 수 없습니다."));
+        Project project = ProjectMapper.toEntity(request, author);
+        if (project.getReadme() != null && !project.getReadme().isBlank()) {
+            String summary = aiSummaryPort.summarize(project.getReadme(), project.getDescription());
+            project.updateSummary(summary);
+        }
+        Project saved = repository.save(project);
+        publishIndexEvent(saved);
+        return ProjectMapper.toResponse(saved);
+    }
+
+    public Page<ProjectResponse> searchProjects(SearchRequest request) {
+        Objects.requireNonNull(request, "SearchRequest must not be null");
+        var searchResults = searchPort.search(request.toSearchQuery());
+        var responses = searchResults.stream()
+                .map(ProjectMapper::toResponse)
+                .collect(Collectors.toList());
+        return new PageImpl<>(responses, PageRequest.of(request.page(), request.size()), responses.size());
+    }
+
+    public AiRecommendResponse recommendByQuery(String naturalQuery) {
+        Objects.requireNonNull(naturalQuery, "naturalQuery must not be null");
+        float[] queryEmbedding = embeddingPort.embed(naturalQuery);
+        List<VectorMatch> matches = vectorPort.searchSimilar(queryEmbedding, 5);
+        List<Long> projectIds = matches.stream()
+                .map(VectorMatch::projectId)
+                .collect(Collectors.toList());
+        List<ProjectContext> retrievedDocs = repository.findAllById(projectIds).stream()
+                .map(project -> new ProjectContext(
+                        project.getId(),
+                        project.getTitle(),
+                        project.getDescription(),
+                        project.getReadme(),
+                        project.getDifficulty(),
+                        project.getDomain()
+                ))
+                .collect(Collectors.toList());
+        var recommendation = aiRecommendationPort.recommend(naturalQuery, retrievedDocs);
+        return new AiRecommendResponse(
+                recommendation.answer(),
+                recommendation.recommendedProjectIds(),
+                recommendation.reasoning()
+        );
+    }
+
+    public ProjectResponse getProject(Long id) {
+        Project project = repository.findById(id).orElseThrow(() -> new ProjectNotFoundException(id));
+        return ProjectMapper.toResponse(project);
+    }
+
+    public ProjectResponse updateProject(Long id, ProjectUpdateRequest request, Long currentUserId, boolean isAdmin) {
+        Objects.requireNonNull(request, "ProjectUpdateRequest must not be null");
+        Project project = repository.findById(id).orElseThrow(() -> new ProjectNotFoundException(id));
+        User currentUser = userRepository.findById(currentUserId)
+                .orElseThrow(() -> new ProjectException(ErrorCode.USER_NOT_FOUND, "사용자를 찾을 수 없습니다."));
+        if (!isAdmin && !project.isAuthor(currentUser)) {
+            throw new ProjectException(ErrorCode.NOT_PROJECT_OWNER, "프로젝트 수정 권한이 없습니다.");
+        }
+        ProjectMapper.applyUpdate(request, project);
+        if (project.getReadme() != null && !project.getReadme().isBlank()) {
+            String summary = aiSummaryPort.summarize(project.getReadme(), project.getDescription());
+            project.updateSummary(summary);
+        }
+        Project updated = repository.save(project);
+        publishIndexEvent(updated);
+        return ProjectMapper.toResponse(updated);
+    }
+
+    public void deleteProject(Long id, Long currentUserId, boolean isAdmin) {
+        Project project = repository.findById(id).orElseThrow(() -> new ProjectNotFoundException(id));
+        User currentUser = userRepository.findById(currentUserId)
+                .orElseThrow(() -> new ProjectException(ErrorCode.USER_NOT_FOUND, "사용자를 찾을 수 없습니다."));
+        if (!isAdmin && !project.isAuthor(currentUser)) {
+            throw new ProjectException(ErrorCode.NOT_PROJECT_OWNER, "프로젝트 삭제 권한이 없습니다.");
+        }
+        repository.deleteById(id);
+        eventPublisher.publishEvent(new ProjectDeleteEvent(id));
+    }
+
+    private void publishIndexEvent(Project project) {
+        ProjectIndexDocument indexDocument = new ProjectIndexDocument(
+                project.getId(),
+                project.getTitle(),
+                project.getSummary(),
+                project.getDescription(),
+                project.getTechStacks(),
+                project.getYear(),
+                project.getSemester(),
+                project.getDifficulty()
+        );
+        String embeddingText = buildEmbeddingText(project);
+        eventPublisher.publishEvent(new ProjectIndexEvent(project.getId(), indexDocument, embeddingText));
+    }
+
+    private String buildEmbeddingText(Project project) {
+        StringBuilder builder = new StringBuilder();
+        builder.append(project.getTitle());
+        if (project.getSummary() != null) {
+            builder.append(" \n").append(project.getSummary());
+        }
+        if (project.getDescription() != null) {
+            builder.append(" \n").append(project.getDescription());
+        }
+        if (project.getReadme() != null) {
+            builder.append(" \n").append(project.getReadme());
+        }
+        return builder.toString();
+    }
+}

--- a/backend/src/main/java/com/ctrl/cbnu_archive/project/service/adapter/mock/MockAiRecommendationAdapter.java
+++ b/backend/src/main/java/com/ctrl/cbnu_archive/project/service/adapter/mock/MockAiRecommendationAdapter.java
@@ -1,0 +1,45 @@
+package com.ctrl.cbnu_archive.project.service.adapter.mock;
+
+import com.ctrl.cbnu_archive.project.service.port.AiRecommendationPort;
+import com.ctrl.cbnu_archive.project.service.port.AiRecommendationResult;
+import com.ctrl.cbnu_archive.project.service.port.ProjectContext;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+
+@Component
+@ConditionalOnProperty(prefix = "app.adapter", name = "ai-recommendation", havingValue = "mock", matchIfMissing = true)
+public class MockAiRecommendationAdapter implements AiRecommendationPort {
+
+    private static final Logger log = LoggerFactory.getLogger(MockAiRecommendationAdapter.class);
+
+    @Override
+    public AiRecommendationResult recommend(String userQuery, List<ProjectContext> retrievedDocs) {
+        Objects.requireNonNull(userQuery, "userQuery must not be null");
+        if (retrievedDocs == null) {
+            retrievedDocs = List.of();
+        }
+        log.info("[MOCK] called recommend(userQuery={}, retrievedDocs={})", userQuery, retrievedDocs.size());
+
+        List<Long> recommendedProjectIds = retrievedDocs.stream()
+                .map(ProjectContext::projectId)
+                .limit(3)
+                .collect(Collectors.toList());
+
+        String answer = String.format(
+                "[MOCK] 질문에 대한 추천 결과입니다. 입력하신 질의: '%s'. 총 %d개 프로젝트에서 후보를 찾았습니다.",
+                userQuery,
+                retrievedDocs.size()
+        );
+        String reasoning = String.format(
+                "문장에 포함된 키워드와 검색된 프로젝트의 제목/설명을 기반으로 추천 목록을 생성했습니다. 추천 프로젝트 개수: %d.",
+                recommendedProjectIds.size()
+        );
+
+        return new AiRecommendationResult(answer, recommendedProjectIds, reasoning);
+    }
+}

--- a/backend/src/main/java/com/ctrl/cbnu_archive/project/service/adapter/mock/MockAiSummaryAdapter.java
+++ b/backend/src/main/java/com/ctrl/cbnu_archive/project/service/adapter/mock/MockAiSummaryAdapter.java
@@ -1,0 +1,96 @@
+package com.ctrl.cbnu_archive.project.service.adapter.mock;
+
+import com.ctrl.cbnu_archive.project.service.port.AiSummaryPort;
+import com.ctrl.cbnu_archive.project.service.port.ExtractedMetadata;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Objects;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+
+@Component
+@ConditionalOnProperty(prefix = "app.adapter", name = "ai-summary", havingValue = "mock", matchIfMissing = true)
+public class MockAiSummaryAdapter implements AiSummaryPort {
+
+    private static final Logger log = LoggerFactory.getLogger(MockAiSummaryAdapter.class);
+
+    @Override
+    public String summarize(String readme, String description) {
+        Objects.requireNonNull(readme, "readme must not be null");
+        Objects.requireNonNull(description, "description must not be null");
+        log.info("[MOCK] called summarize(readmeLength={}, descriptionLength={})", readme.length(), description.length());
+        String summary = String.format(
+                "[MOCK] 요약: %s... 주요 내용: %s...",
+                trimText(readme, 120),
+                trimText(description, 120)
+        );
+        return summary;
+    }
+
+    @Override
+    public ExtractedMetadata extractMetadata(String text) {
+        Objects.requireNonNull(text, "text must not be null");
+        log.info("[MOCK] called extractMetadata(textLength={})", text.length());
+        List<String> techStacks = new ArrayList<>();
+        String lower = text.toLowerCase(Locale.ROOT);
+        if (lower.contains("spring")) {
+            techStacks.add("Spring");
+        }
+        if (lower.contains("react")) {
+            techStacks.add("React");
+        }
+        if (lower.contains("postgres")) {
+            techStacks.add("PostgreSQL");
+        }
+        if (lower.contains("java")) {
+            techStacks.add("Java");
+        }
+        if (lower.contains("python")) {
+            techStacks.add("Python");
+        }
+        if (lower.contains("docker")) {
+            techStacks.add("Docker");
+        }
+        if (techStacks.isEmpty()) {
+            techStacks.add("기타");
+        }
+
+        String domain = guessDomain(lower);
+        String difficulty = guessDifficulty(lower);
+
+        return new ExtractedMetadata(techStacks, domain, difficulty);
+    }
+
+    private String trimText(String text, int maxLength) {
+        if (text.length() <= maxLength) {
+            return text;
+        }
+        return text.substring(0, maxLength).trim() + "...";
+    }
+
+    private String guessDomain(String lower) {
+        if (lower.contains("cms") || lower.contains("content")) {
+            return "콘텐츠 관리";
+        }
+        if (lower.contains("search") || lower.contains("검색")) {
+            return "검색 엔진";
+        }
+        if (lower.contains("chat") || lower.contains("dialog")) {
+            return "대화형 AI";
+        }
+        return "일반 프로젝트";
+    }
+
+    private String guessDifficulty(String lower) {
+        if (lower.contains("advanced") || lower.contains("high") || lower.contains("complex")) {
+            return "High";
+        }
+        if (lower.contains("intermediate") || lower.contains("medium")) {
+            return "Medium";
+        }
+        return "Low";
+    }
+}

--- a/backend/src/main/java/com/ctrl/cbnu_archive/project/service/adapter/mock/MockEmbeddingAdapter.java
+++ b/backend/src/main/java/com/ctrl/cbnu_archive/project/service/adapter/mock/MockEmbeddingAdapter.java
@@ -1,0 +1,48 @@
+package com.ctrl.cbnu_archive.project.service.adapter.mock;
+
+import com.ctrl.cbnu_archive.project.service.port.EmbeddingPort;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+
+@Component
+@ConditionalOnProperty(prefix = "app.adapter", name = "embedding", havingValue = "mock", matchIfMissing = true)
+public class MockEmbeddingAdapter implements EmbeddingPort {
+
+    private static final Logger log = LoggerFactory.getLogger(MockEmbeddingAdapter.class);
+    private static final int DIMENSION = 384;
+
+    @Override
+    public float[] embed(String text) {
+        Objects.requireNonNull(text, "text must not be null");
+        log.info("[MOCK] called embed(textLength={})", text.length());
+        return buildFakeEmbedding(text);
+    }
+
+    @Override
+    public List<float[]> embedBatch(List<String> texts) {
+        Objects.requireNonNull(texts, "texts must not be null");
+        log.info("[MOCK] called embedBatch(batchSize={})", texts.size());
+        var results = new ArrayList<float[]>(texts.size());
+        for (String text : texts) {
+            results.add(buildFakeEmbedding(text));
+        }
+        return results;
+    }
+
+    private float[] buildFakeEmbedding(String text) {
+        byte[] bytes = text.getBytes(StandardCharsets.UTF_8);
+        float[] embedding = new float[DIMENSION];
+        int seed = Math.abs(text.hashCode());
+        for (int i = 0; i < DIMENSION; i++) {
+            int index = (seed + i) % bytes.length;
+            embedding[i] = ((bytes[index] & 0xFF) / 255f) * ((i % 10 + 1) / 10f);
+        }
+        return embedding;
+    }
+}

--- a/backend/src/main/java/com/ctrl/cbnu_archive/project/service/adapter/mock/MockProjectSearchAdapter.java
+++ b/backend/src/main/java/com/ctrl/cbnu_archive/project/service/adapter/mock/MockProjectSearchAdapter.java
@@ -1,0 +1,99 @@
+package com.ctrl.cbnu_archive.project.service.adapter.mock;
+
+import com.ctrl.cbnu_archive.project.service.port.ProjectIndexDocument;
+import com.ctrl.cbnu_archive.project.service.port.ProjectSearchPort;
+import com.ctrl.cbnu_archive.project.service.port.ProjectSearchResult;
+import com.ctrl.cbnu_archive.project.service.port.SearchQuery;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+
+@Component
+@ConditionalOnProperty(prefix = "app.adapter", name = "search", havingValue = "mock", matchIfMissing = true)
+public class MockProjectSearchAdapter implements ProjectSearchPort {
+
+    private static final Logger log = LoggerFactory.getLogger(MockProjectSearchAdapter.class);
+    private final Map<Long, ProjectIndexDocument> indexStore = new ConcurrentHashMap<>();
+
+    @Override
+    public void index(ProjectIndexDocument doc) {
+        Objects.requireNonNull(doc, "ProjectIndexDocument must not be null");
+        log.info("[MOCK] called index(projectId={})", doc.projectId());
+        indexStore.put(doc.projectId(), doc);
+    }
+
+    @Override
+    public void delete(Long projectId) {
+        log.info("[MOCK] called delete(projectId={})", projectId);
+        indexStore.remove(projectId);
+    }
+
+    @Override
+    public List<ProjectSearchResult> search(SearchQuery query) {
+        log.info("[MOCK] called search(query={})", query);
+        if (query == null) {
+            return Collections.emptyList();
+        }
+        List<ProjectSearchResult> candidates = indexStore.values().stream()
+                .filter(doc -> matchesKeyword(doc, query.keyword()))
+                .filter(doc -> matchesListFilter(doc.techStacks(), query.techStacks()))
+                .filter(doc -> matchesValue(doc.year(), query.year()))
+                .filter(doc -> matchesValue(doc.semester(), query.semester()))
+                .filter(doc -> matchesValue(doc.difficulty(), query.difficulty()))
+                .map(doc -> new ProjectSearchResult(
+                        doc.projectId(),
+                        doc.title(),
+                        doc.summary(),
+                        doc.techStacks(),
+                        doc.year(),
+                        doc.semester(),
+                        doc.difficulty(),
+                        1.0f
+                ))
+                .collect(Collectors.toList());
+
+        int from = Math.max(0, query.page() * query.size());
+        int to = Math.min(candidates.size(), from + query.size());
+        if (from >= to) {
+            return Collections.emptyList();
+        }
+        return new ArrayList<>(candidates.subList(from, to));
+    }
+
+    private boolean matchesKeyword(ProjectIndexDocument doc, String keyword) {
+        if (keyword == null || keyword.isBlank()) {
+            return true;
+        }
+        String lower = keyword.toLowerCase();
+        return doc.title().toLowerCase().contains(lower)
+                || doc.summary().toLowerCase().contains(lower)
+                || doc.description().toLowerCase().contains(lower);
+    }
+
+    private boolean matchesListFilter(List<String> values, List<String> filter) {
+        if (filter == null || filter.isEmpty()) {
+            return true;
+        }
+        if (values == null || values.isEmpty()) {
+            return false;
+        }
+        return values.stream().map(String::toLowerCase).collect(Collectors.toSet()).containsAll(
+                filter.stream().map(String::toLowerCase).collect(Collectors.toSet())
+        );
+    }
+
+    private boolean matchesValue(Object actual, Object expected) {
+        if (expected == null) {
+            return true;
+        }
+        return expected.equals(actual);
+    }
+}

--- a/backend/src/main/java/com/ctrl/cbnu_archive/project/service/adapter/mock/MockVectorSearchAdapter.java
+++ b/backend/src/main/java/com/ctrl/cbnu_archive/project/service/adapter/mock/MockVectorSearchAdapter.java
@@ -1,0 +1,70 @@
+package com.ctrl.cbnu_archive.project.service.adapter.mock;
+
+import com.ctrl.cbnu_archive.project.service.port.VectorMatch;
+import com.ctrl.cbnu_archive.project.service.port.VectorSearchPort;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+
+@Component
+@ConditionalOnProperty(prefix = "app.adapter", name = "vector", havingValue = "mock", matchIfMissing = true)
+public class MockVectorSearchAdapter implements VectorSearchPort {
+
+    private static final Logger log = LoggerFactory.getLogger(MockVectorSearchAdapter.class);
+    private final Map<Long, float[]> embeddings = new ConcurrentHashMap<>();
+    private final Map<Long, Map<String, Object>> metadata = new ConcurrentHashMap<>();
+
+    @Override
+    public void upsert(Long projectId, float[] embedding, Map<String, Object> metadata) {
+        Objects.requireNonNull(projectId, "projectId must not be null");
+        Objects.requireNonNull(embedding, "embedding must not be null");
+        log.info("[MOCK] called upsert(projectId={}, embeddingLength={}, metadata={})", projectId, embedding.length, metadata);
+        this.embeddings.put(projectId, embedding.clone());
+        this.metadata.put(projectId, metadata == null ? Map.of() : Map.copyOf(metadata));
+    }
+
+    @Override
+    public List<VectorMatch> searchSimilar(float[] queryEmbedding, int topK) {
+        Objects.requireNonNull(queryEmbedding, "queryEmbedding must not be null");
+        log.info("[MOCK] called searchSimilar(topK={}, queryEmbeddingLength={})", topK, queryEmbedding.length);
+        List<VectorMatch> scored = new ArrayList<>();
+        for (var entry : embeddings.entrySet()) {
+            float score = cosineSimilarity(queryEmbedding, entry.getValue());
+            scored.add(new VectorMatch(entry.getKey(), score, metadata.getOrDefault(entry.getKey(), Map.of())));
+        }
+        scored.sort(Comparator.comparing(VectorMatch::score).reversed());
+        return scored.stream().limit(topK).toList();
+    }
+
+    @Override
+    public void delete(Long projectId) {
+        log.info("[MOCK] called delete(projectId={})", projectId);
+        embeddings.remove(projectId);
+        metadata.remove(projectId);
+    }
+
+    private float cosineSimilarity(float[] a, float[] b) {
+        if (a.length != b.length) {
+            return 0f;
+        }
+        double dot = 0.0;
+        double normA = 0.0;
+        double normB = 0.0;
+        for (int i = 0; i < a.length; i++) {
+            dot += a[i] * b[i];
+            normA += a[i] * a[i];
+            normB += b[i] * b[i];
+        }
+        if (normA == 0 || normB == 0) {
+            return 0f;
+        }
+        return (float) (dot / (Math.sqrt(normA) * Math.sqrt(normB)));
+    }
+}

--- a/backend/src/main/java/com/ctrl/cbnu_archive/project/service/event/ProjectDeleteEvent.java
+++ b/backend/src/main/java/com/ctrl/cbnu_archive/project/service/event/ProjectDeleteEvent.java
@@ -1,0 +1,4 @@
+package com.ctrl.cbnu_archive.project.service.event;
+
+public record ProjectDeleteEvent(Long projectId) {
+}

--- a/backend/src/main/java/com/ctrl/cbnu_archive/project/service/event/ProjectIndexEvent.java
+++ b/backend/src/main/java/com/ctrl/cbnu_archive/project/service/event/ProjectIndexEvent.java
@@ -1,0 +1,10 @@
+package com.ctrl.cbnu_archive.project.service.event;
+
+import com.ctrl.cbnu_archive.project.service.port.ProjectIndexDocument;
+
+public record ProjectIndexEvent(
+        Long projectId,
+        ProjectIndexDocument indexDocument,
+        String embeddingText
+) {
+}

--- a/backend/src/main/java/com/ctrl/cbnu_archive/project/service/event/ProjectIndexEventListener.java
+++ b/backend/src/main/java/com/ctrl/cbnu_archive/project/service/event/ProjectIndexEventListener.java
@@ -1,0 +1,55 @@
+package com.ctrl.cbnu_archive.project.service.event;
+
+import com.ctrl.cbnu_archive.project.service.port.EmbeddingPort;
+import com.ctrl.cbnu_archive.project.service.port.ProjectIndexDocument;
+import com.ctrl.cbnu_archive.project.service.port.ProjectSearchPort;
+import com.ctrl.cbnu_archive.project.service.port.VectorSearchPort;
+import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ProjectIndexEventListener {
+
+    private static final Logger log = LoggerFactory.getLogger(ProjectIndexEventListener.class);
+    private final ProjectSearchPort searchPort;
+    private final VectorSearchPort vectorPort;
+    private final EmbeddingPort embeddingPort;
+
+    public ProjectIndexEventListener(
+            ProjectSearchPort searchPort,
+            VectorSearchPort vectorPort,
+            EmbeddingPort embeddingPort
+    ) {
+        this.searchPort = searchPort;
+        this.vectorPort = vectorPort;
+        this.embeddingPort = embeddingPort;
+    }
+
+    @Async
+    @EventListener
+    public void handleProjectIndexEvent(ProjectIndexEvent event) {
+        ProjectIndexDocument document = event.indexDocument();
+        log.info("[EVENT] ProjectIndexEvent handle projectId={}", event.projectId());
+        searchPort.index(document);
+        float[] embedding = embeddingPort.embed(event.embeddingText());
+        Map<String, Object> metadata = Map.of(
+                "title", document.title(),
+                "difficulty", document.difficulty(),
+                "year", document.year(),
+                "semester", document.semester()
+        );
+        vectorPort.upsert(event.projectId(), embedding, metadata);
+    }
+
+    @Async
+    @EventListener
+    public void handleProjectDeleteEvent(ProjectDeleteEvent event) {
+        log.info("[EVENT] ProjectDeleteEvent handle projectId={}", event.projectId());
+        searchPort.delete(event.projectId());
+        vectorPort.delete(event.projectId());
+    }
+}

--- a/backend/src/main/java/com/ctrl/cbnu_archive/project/service/exception/ProjectNotFoundException.java
+++ b/backend/src/main/java/com/ctrl/cbnu_archive/project/service/exception/ProjectNotFoundException.java
@@ -1,0 +1,7 @@
+package com.ctrl.cbnu_archive.project.service.exception;
+
+public class ProjectNotFoundException extends RuntimeException {
+    public ProjectNotFoundException(Long projectId) {
+        super("Project not found: " + projectId);
+    }
+}

--- a/backend/src/main/java/com/ctrl/cbnu_archive/project/service/port/AiRecommendationPort.java
+++ b/backend/src/main/java/com/ctrl/cbnu_archive/project/service/port/AiRecommendationPort.java
@@ -1,0 +1,7 @@
+package com.ctrl.cbnu_archive.project.service.port;
+
+import java.util.List;
+
+public interface AiRecommendationPort {
+    AiRecommendationResult recommend(String userQuery, List<ProjectContext> retrievedDocs);
+}

--- a/backend/src/main/java/com/ctrl/cbnu_archive/project/service/port/AiRecommendationResult.java
+++ b/backend/src/main/java/com/ctrl/cbnu_archive/project/service/port/AiRecommendationResult.java
@@ -1,0 +1,10 @@
+package com.ctrl.cbnu_archive.project.service.port;
+
+import java.util.List;
+
+public record AiRecommendationResult(
+        String answer,
+        List<Long> recommendedProjectIds,
+        String reasoning
+) {
+}

--- a/backend/src/main/java/com/ctrl/cbnu_archive/project/service/port/AiSummaryPort.java
+++ b/backend/src/main/java/com/ctrl/cbnu_archive/project/service/port/AiSummaryPort.java
@@ -1,0 +1,6 @@
+package com.ctrl.cbnu_archive.project.service.port;
+
+public interface AiSummaryPort {
+    String summarize(String readme, String description);
+    ExtractedMetadata extractMetadata(String text);
+}

--- a/backend/src/main/java/com/ctrl/cbnu_archive/project/service/port/EmbeddingPort.java
+++ b/backend/src/main/java/com/ctrl/cbnu_archive/project/service/port/EmbeddingPort.java
@@ -1,0 +1,8 @@
+package com.ctrl.cbnu_archive.project.service.port;
+
+import java.util.List;
+
+public interface EmbeddingPort {
+    float[] embed(String text);
+    List<float[]> embedBatch(List<String> texts);
+}

--- a/backend/src/main/java/com/ctrl/cbnu_archive/project/service/port/ExtractedMetadata.java
+++ b/backend/src/main/java/com/ctrl/cbnu_archive/project/service/port/ExtractedMetadata.java
@@ -1,0 +1,10 @@
+package com.ctrl.cbnu_archive.project.service.port;
+
+import java.util.List;
+
+public record ExtractedMetadata(
+        List<String> techStacks,
+        String domain,
+        String difficulty
+) {
+}

--- a/backend/src/main/java/com/ctrl/cbnu_archive/project/service/port/ProjectContext.java
+++ b/backend/src/main/java/com/ctrl/cbnu_archive/project/service/port/ProjectContext.java
@@ -1,0 +1,11 @@
+package com.ctrl.cbnu_archive.project.service.port;
+
+public record ProjectContext(
+        Long projectId,
+        String title,
+        String description,
+        String readme,
+        String difficulty,
+        String domain
+) {
+}

--- a/backend/src/main/java/com/ctrl/cbnu_archive/project/service/port/ProjectIndexDocument.java
+++ b/backend/src/main/java/com/ctrl/cbnu_archive/project/service/port/ProjectIndexDocument.java
@@ -1,0 +1,15 @@
+package com.ctrl.cbnu_archive.project.service.port;
+
+import java.util.List;
+
+public record ProjectIndexDocument(
+        Long projectId,
+        String title,
+        String summary,
+        String description,
+        List<String> techStacks,
+        Integer year,
+        String semester,
+        String difficulty
+) {
+}

--- a/backend/src/main/java/com/ctrl/cbnu_archive/project/service/port/ProjectSearchPort.java
+++ b/backend/src/main/java/com/ctrl/cbnu_archive/project/service/port/ProjectSearchPort.java
@@ -1,0 +1,9 @@
+package com.ctrl.cbnu_archive.project.service.port;
+
+import java.util.List;
+
+public interface ProjectSearchPort {
+    void index(ProjectIndexDocument doc);
+    void delete(Long projectId);
+    List<ProjectSearchResult> search(SearchQuery query);
+}

--- a/backend/src/main/java/com/ctrl/cbnu_archive/project/service/port/ProjectSearchResult.java
+++ b/backend/src/main/java/com/ctrl/cbnu_archive/project/service/port/ProjectSearchResult.java
@@ -1,0 +1,15 @@
+package com.ctrl.cbnu_archive.project.service.port;
+
+import java.util.List;
+
+public record ProjectSearchResult(
+        Long projectId,
+        String title,
+        String summary,
+        List<String> techStacks,
+        Integer year,
+        String semester,
+        String difficulty,
+        float score
+) {
+}

--- a/backend/src/main/java/com/ctrl/cbnu_archive/project/service/port/SearchQuery.java
+++ b/backend/src/main/java/com/ctrl/cbnu_archive/project/service/port/SearchQuery.java
@@ -1,0 +1,14 @@
+package com.ctrl.cbnu_archive.project.service.port;
+
+import java.util.List;
+
+public record SearchQuery(
+        String keyword,
+        List<String> techStacks,
+        Integer year,
+        String semester,
+        String difficulty,
+        int page,
+        int size
+) {
+}

--- a/backend/src/main/java/com/ctrl/cbnu_archive/project/service/port/VectorMatch.java
+++ b/backend/src/main/java/com/ctrl/cbnu_archive/project/service/port/VectorMatch.java
@@ -1,0 +1,10 @@
+package com.ctrl.cbnu_archive.project.service.port;
+
+import java.util.Map;
+
+public record VectorMatch(
+        Long projectId,
+        float score,
+        Map<String, Object> metadata
+) {
+}

--- a/backend/src/main/java/com/ctrl/cbnu_archive/project/service/port/VectorSearchPort.java
+++ b/backend/src/main/java/com/ctrl/cbnu_archive/project/service/port/VectorSearchPort.java
@@ -1,0 +1,10 @@
+package com.ctrl.cbnu_archive.project.service.port;
+
+import java.util.List;
+import java.util.Map;
+
+public interface VectorSearchPort {
+    void upsert(Long projectId, float[] embedding, Map<String, Object> metadata);
+    List<VectorMatch> searchSimilar(float[] queryEmbedding, int topK);
+    void delete(Long projectId);
+}

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -1,0 +1,16 @@
+jwt:
+  secret: dGVzdC1zZWNyZXQta2V5LWZvci1jYm51LWFyY2hpdmUtcHJvamVjdC1tdXN0LWJlLWxvbmctZW5vdWdoLWZvci1obWFjLXNoYS0yNTY=
+  access-token-expiry: 1800000
+  refresh-token-expiry: 1209600000
+
+app:
+  cors:
+    allowed-origins:
+      - http://localhost:3000
+      - http://localhost:5173
+
+spring:
+  servlet:
+    multipart:
+      max-file-size: 50MB
+      max-request-size: 100MB


### PR DESCRIPTION
## 📌 작업 내용

백엔드 서버 초기 구축 및 핵심 도메인 기능 구현

##  아키텍처

**헥사고날(Port-Adapter) 아키텍처** 적용. 외부 의존성(DB, AI, 검색엔진, 파일 스토리지)을 모두 인터페이스로 추상화하여 실제 구현체가 미정인 상태에서도 Mock 어댑터로 전체 흐름 검증 가능. 추후 PostgreSQL/OpenSearch/Claude/MinIO 확정 시 어댑터만 교체하면 됨.

## 구현 내용

### 인증 (Auth)
- 회원가입, 로그인, 토큰 재발급
- JWT 기반 stateless 인증 (jjwt 0.12.5)
- BCrypt 비밀번호 해시

### 마이페이지 (User)
- 내 정보 조회/수정
- 비밀번호 변경 (현재 비번 검증)
- 내가 올린 프로젝트 목록 조회

### 프로젝트 (Project)
- 프로젝트 CRUD
- 키워드 + 필터 검색 (연도/학기/난이도/도메인)
- 자연어 기반 AI 추천 (RAG 흐름)
- 작성자 본인/ADMIN만 수정·삭제

### 파일 (File)
- multipart 파일 업로드/다운로드/삭제
- 작성자 검증

### 공통 (Global)
- ApiResponse 공통 응답 포맷
- GlobalExceptionHandler + ErrorCode
- BaseTimeEntity (createdAt/updatedAt)
- Spring Security + CORS
- Swagger UI

## 🧪 테스트 방법

1. `cd backend && ./gradlew bootRun`
2. http://localhost:8080/swagger-ui/index.html 접속
3. 회원가입 → 로그인 → Authorize 🔒 → 프로젝트 등록 → AI 추천 시나리오 테스트 가능

## 📝 향후 작업

- [ ] PostgreSQL 어댑터 (DB 확정 후)
- [ ] MinIO 파일 스토리지 어댑터
- [ ] OpenSearch 검색 어댑터
- [ ] Claude API RAG 어댑터 (AI 확정 후)
- [ ] FastAPI 임베딩 서버 어댑터
- [ ] TechStack 엔티티 추가
- [ ] 통합 테스트 작성