### PR TITLE
[FIX] 자연어 검색 백엔드 연동 및 응답 타입 불일치 수정

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 .frontend-devspec.md
 .agents
 copilot-instructions.md
+seed_projects.py
 
 # =========================
 # Operating System & IDE

--- a/frontend/src/api/search.ts
+++ b/frontend/src/api/search.ts
@@ -50,11 +50,31 @@ export const searchKeyword = (params: KeywordSearchParams) =>
       return result
     })
 
+// Backend recommend response shape
+interface BackendRecommendResult {
+  answer: string
+  recommendedProjectIds: number[]
+  reasoning: string
+}
+
+export interface NaturalSearchBackendResult {
+  answer: string
+  reasoning: string
+  projects: ProjectSummary[]
+}
+
 // Natural language recommendation via backend AI adapter
-export const searchNatural = (query: string, sessionId?: string) =>
-  api
-    .post<{ data: NaturalSearchResult }>('/api/v1/projects/recommend', { query, sessionId })
-    .then((r) => r.data.data)
+// Fetches each recommended project by ID in parallel after getting the ID list
+export const searchNatural = async (query: string): Promise<NaturalSearchBackendResult> => {
+  const res = await api.post<{ data: BackendRecommendResult }>('/api/v1/projects/recommend', { query })
+  const { answer, recommendedProjectIds, reasoning } = res.data.data
+  const projects = await Promise.all(
+    recommendedProjectIds.map((id) =>
+      api.get<{ data: BackendProjectResponse }>(`/api/v1/projects/${id}`).then((r) => toSummary(r.data.data)),
+    ),
+  )
+  return { answer, reasoning, projects }
+}
 
 // Direct AI service call — fallback when backend AI adapter is unavailable
 const aiApi = axios.create({

--- a/frontend/src/pages/Chat.tsx
+++ b/frontend/src/pages/Chat.tsx
@@ -1,35 +1,14 @@
 import { useState, useRef, useEffect } from 'react'
 import { useChatStore } from '@/store/chatStore'
-import { searchNaturalDirect } from '@/api/search'
+import { searchNatural } from '@/api/search'
 import { ProjectCard } from '@/components/project/ProjectCard'
-import type { NaturalSearchResultItem } from '@/types/chat'
 import type { ProjectSummary } from '@/types/project'
-
-// Convert AI result item to ProjectSummary for display in chat bubbles
-function toProjectSummary(item: NaturalSearchResultItem): ProjectSummary {
-  return {
-    id: item.project_id,
-    title: item.title,
-    summary: item.topic,
-    year: 0,
-    semester: 1,
-    subjectName: item.project_type,
-    teamName: '',
-    techStacks: item.tech_stack,
-    tags: item.keywords,
-    status: 'APPROVED',
-    viewCount: 0,
-    downloadCount: 0,
-    createdAt: '',
-  }
-}
 
 // Each message in the conversation (extends base ChatMessage with AI result metadata)
 interface DisplayMessage {
   role: 'user' | 'assistant'
   content: string
   projects?: ProjectSummary[]
-  matchReasonMap?: Record<number, string[]>  // project_id → reasons
 }
 
 export default function Chat() {
@@ -57,20 +36,12 @@ export default function Chat() {
     setLoading(true)
 
     try {
-      const result = await searchNaturalDirect(text)
-
-      // Build project list and reason map from AI results
-      const projects = result.results.map(toProjectSummary)
-      const reasonMap: Record<number, string[]> = {}
-      result.results.forEach((item) => {
-        reasonMap[item.project_id] = item.reasons
-      })
+      const result = await searchNatural(text)
 
       const assistantMsg: DisplayMessage = {
         role: 'assistant',
-        content: result.llm_answer ?? '관련 프로젝트를 찾았습니다.',
-        projects,
-        matchReasonMap: reasonMap,
+        content: result.answer || '관련 프로젝트를 찾았습니다.',
+        projects: result.projects,
       }
       setMessages((prev) => [...prev, assistantMsg])
     } catch {
@@ -125,7 +96,6 @@ export default function Chat() {
                     <ProjectCard
                       key={project.id}
                       project={project}
-                      matchReasons={msg.matchReasonMap?.[project.id]}
                     />
                   ))}
                 </div>

--- a/frontend/src/pages/ProjectList.tsx
+++ b/frontend/src/pages/ProjectList.tsx
@@ -3,28 +3,9 @@ import { SearchBar } from '@/components/search/SearchBar'
 import { FilterPanel } from '@/components/search/FilterPanel'
 import { ProjectCard } from '@/components/project/ProjectCard'
 import { useSearchStore } from '@/store/searchStore'
-import { searchNaturalDirect, searchKeyword } from '@/api/search'
-import type { NaturalSearchResultItem, NaturalSearchResult } from '@/types/chat'
+import { searchNatural, searchKeyword } from '@/api/search'
+import type { NaturalSearchBackendResult } from '@/api/search'
 import type { ProjectSummary } from '@/types/project'
-
-// Map AI service result item to the ProjectSummary shape ProjectCard expects
-function toProjectSummary(item: NaturalSearchResultItem): ProjectSummary {
-  return {
-    id: item.project_id,
-    title: item.title,
-    summary: item.topic,
-    year: 0,
-    semester: 1,
-    subjectName: item.project_type,
-    teamName: '',
-    techStacks: item.tech_stack,
-    tags: item.keywords,
-    status: 'APPROVED',
-    viewCount: 0,
-    downloadCount: 0,
-    createdAt: '',
-  }
-}
 
 export default function ProjectList() {
   const { keyword, searchType, filters } = useSearchStore()
@@ -33,7 +14,7 @@ export default function ProjectList() {
   const [error, setError] = useState<string | null>(null)
 
   // Natural search state
-  const [naturalResult, setNaturalResult] = useState<NaturalSearchResult | null>(null)
+  const [naturalResult, setNaturalResult] = useState<NaturalSearchBackendResult | null>(null)
 
   // Keyword search state (backend stub); pre-populated on mount
   const [keywordProjects, setKeywordProjects] = useState<ProjectSummary[]>([])
@@ -55,8 +36,7 @@ export default function ProjectList() {
 
     try {
       if (searchType === 'natural') {
-        // Call AI service directly while backend proxy is not implemented
-        const result = await searchNaturalDirect(keyword)
+        const result = await searchNatural(keyword)
         setNaturalResult(result)
       } else {
         // Keyword search through backend; returns empty list until backend is ready
@@ -75,7 +55,7 @@ export default function ProjectList() {
   }, [keyword, searchType, filters])
 
   // Derive display list from whichever search mode is active
-  const naturalItems = naturalResult?.results ?? []
+  const naturalItems = naturalResult?.projects ?? []
   const displayProjects = searchType === 'keyword' ? keywordProjects : []
   // Consider page "has results" when there's anything to show
   const hasResults = searchType === 'natural' ? naturalItems.length > 0 : displayProjects.length > 0
@@ -94,11 +74,11 @@ export default function ProjectList() {
 
         {/* Main results area */}
         <section className="min-w-0 flex-1">
-          {/* AI LLM summary box */}
-          {naturalResult?.llm_answer && (
+          {/* AI answer box */}
+          {naturalResult?.answer && (
             <div className="mb-5 rounded-xl border border-blue-200 bg-blue-50 px-4 py-3 text-sm text-blue-800">
               <p className="mb-1 font-semibold">AI 답변</p>
-              <p className="leading-relaxed">{naturalResult.llm_answer}</p>
+              <p className="leading-relaxed">{naturalResult.answer}</p>
             </div>
           )}
 
@@ -138,15 +118,11 @@ export default function ProjectList() {
           {!isLoading && searchType === 'natural' && naturalItems.length > 0 && (
             <>
               <p className="mb-3 text-sm text-gray-500">
-                총 <span className="font-semibold text-gray-800">{naturalResult!.count}</span>개의 프로젝트를 찾았습니다.
+                총 <span className="font-semibold text-gray-800">{naturalItems.length}</span>개의 프로젝트를 찾았습니다.
               </p>
               <div className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
-                {naturalItems.map((item) => (
-                  <ProjectCard
-                    key={item.project_id}
-                    project={toProjectSummary(item)}
-                    matchReasons={item.reasons}
-                  />
+                {naturalItems.map((project) => (
+                  <ProjectCard key={project.id} project={project} />
                 ))}
               </div>
             </>


### PR DESCRIPTION
## 관련 이슈

Closes #

---

## 변경 내용과 그 이유

### 문제
PR #31 머지 후 자연어 검색 시 "서버 오류" 메시지가 표시되는 버그.

원인은 두 가지였습니다:
1. ProjectList.tsx가 백엔드 릴레이 대신 AI 서비스(`localhost:8000`)를 직접 호출하는 `searchNaturalDirect`를 여전히 사용하고 있었음
2. 백엔드 `/api/v1/projects/recommend` 응답 형식(`{ answer, recommendedProjectIds, reasoning }`)과 프론트엔드가 기대하던 AI 서비스 응답 형식(`{ results, count, llm_answer }`)이 불일치

### 수정

**`frontend/src/api/search.ts`**
- `searchNatural()` 재구현: `/api/v1/projects/recommend`에서 `recommendedProjectIds` 목록을 받은 후, 각 ID에 대해 `/api/v1/projects/{id}`를 병렬 fetch하여 `ProjectSummary[]`로 변환
- `NaturalSearchBackendResult` 타입 신규 export (`{ answer, reasoning, projects }`)
- 더 이상 AI 서비스(`localhost:8000`)를 직접 호출하지 않음

**ProjectList.tsx**
- `searchNaturalDirect` → `searchNatural` 교체
- `NaturalSearchResult` (AI 서비스 타입) → `NaturalSearchBackendResult` 교체
- 결과 렌더링: `naturalResult.results` → `naturalResult.projects`, `count` → `projects.length`, `llm_answer` → `answer`로 변경

---

## 메모 (선택)

- 백엔드 `/recommend`는 현재 MOCK 응답을 반환함 (AI 서비스 미연동). 추천 ID 목록이 실제 DB에 존재하는 프로젝트 ID여야 정상 렌더링됨
- `searchNaturalDirect` 함수는 search.ts에 fallback으로 남겨두었으나, ProjectList.tsx에서는 사용하지 않음