### PR TITLE
[FEAT] 회원가입 화면 구현

### DIFF
--- a/frontend/src/api/auth.ts
+++ b/frontend/src/api/auth.ts
@@ -1,7 +1,6 @@
 import { api } from './axiosInstance'
 import { useAuthStore } from '@/store/authStore'
-import type { UserRole } from '@/types/user'
-import type { LoginRequest } from '@/types/user'
+import type { UserRole, LoginRequest, SignupRequest } from '@/types/user'
 
 // Decode JWT payload without verification (trust the server)
 const decodeJwt = (token: string): Record<string, unknown> => {
@@ -24,6 +23,8 @@ export const login = async (data: LoginRequest): Promise<void> => {
     payload.role as UserRole,
   )
 }
+
+export const signup = (data: SignupRequest) => api.post('/api/v1/auth/signup', data)
 
 // Backend blacklists the access token; Authorization header is added by the interceptor
 export const logout = () => api.post('/api/v1/auth/logout')

--- a/frontend/src/pages/Login.tsx
+++ b/frontend/src/pages/Login.tsx
@@ -1,7 +1,7 @@
 import { useForm } from 'react-hook-form'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { z } from 'zod'
-import { useNavigate, useSearchParams, Navigate } from 'react-router-dom'
+import { useNavigate, useSearchParams, Navigate, Link } from 'react-router-dom'
 import { login } from '@/api/auth'
 import { useAuthStore } from '@/store/authStore'
 
@@ -77,6 +77,12 @@ export default function Login() {
           {isSubmitting ? '로그인 중...' : '로그인'}
         </button>
       </form>
+      <p className="mt-6 text-center text-sm text-gray-500">
+        계정이 없으신가요?{' '}
+        <Link to="/signup" className="font-medium text-primary-600 hover:text-primary-700">
+          회원가입
+        </Link>
+      </p>
     </div>
   )
 }

--- a/frontend/src/pages/SignUp.tsx
+++ b/frontend/src/pages/SignUp.tsx
@@ -1,0 +1,133 @@
+import { useForm } from 'react-hook-form'
+import { zodResolver } from '@hookform/resolvers/zod'
+import { z } from 'zod'
+import { useNavigate, Navigate, Link } from 'react-router-dom'
+import { signup } from '@/api/auth'
+import { useAuthStore } from '@/store/authStore'
+
+const schema = z.object({
+  email: z.string().email('유효한 이메일을 입력해 주세요.').max(100),
+  password: z
+    .string()
+    .min(8, '비밀번호는 최소 8자 이상이어야 합니다.')
+    .max(128),
+  passwordConfirm: z.string().min(1, '필수 항목입니다.'),
+  name: z.string().min(1, '필수 항목입니다.').max(50),
+  studentNumber: z
+    .string()
+    .min(1, '학번은 필수입니다.')
+    .max(20),
+}).refine((data) => data.password === data.passwordConfirm, {
+  // Client-side password mismatch check — not sent to server
+  message: '비밀번호가 일치하지 않습니다.',
+  path: ['passwordConfirm'],
+})
+
+type FormValues = z.infer<typeof schema>
+
+export default function SignUp() {
+  const navigate = useNavigate()
+  const { role } = useAuthStore()
+
+  const {
+    register,
+    handleSubmit,
+    formState: { errors, isSubmitting },
+    setError,
+  } = useForm<FormValues>({ resolver: zodResolver(schema) })
+
+  // Redirect already-logged-in users
+  if (role !== 'GUEST') {
+    return <Navigate to="/" replace />
+  }
+
+  const onSubmit = async (values: FormValues) => {
+    try {
+      await signup({
+        email: values.email,
+        password: values.password,
+        name: values.name,
+        studentNumber: values.studentNumber,
+      })
+      // After signup, send to login page so the user authenticates explicitly
+      navigate('/login', { replace: true })
+    } catch (err: unknown) {
+      // Show server-side error message if available (e.g. duplicate email)
+      const msg =
+        (err as { response?: { data?: { message?: string } } })?.response?.data?.message ??
+        '회원가입 중 오류가 발생했습니다.'
+      setError('root', { message: msg })
+    }
+  }
+
+  const inputClass =
+    'w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary-500'
+  const labelClass = 'mb-1 block text-sm font-medium text-gray-700'
+  const errorClass = 'mt-1 text-xs text-red-500'
+
+  return (
+    <div className="mx-auto mt-16 max-w-sm">
+      <h1 className="mb-2 text-center text-2xl font-bold text-gray-900">회원가입</h1>
+      <p className="mb-8 text-center text-sm text-gray-500">충북대학교 학생 계정으로 가입하세요.</p>
+
+      <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
+        {/* Email */}
+        <div>
+          <label className={labelClass}>이메일</label>
+          <input {...register('email')} type="email" className={inputClass} placeholder="example@cbnu.ac.kr" />
+          {errors.email && <p className={errorClass}>{errors.email.message}</p>}
+        </div>
+
+        {/* Name */}
+        <div>
+          <label className={labelClass}>이름</label>
+          <input {...register('name')} type="text" className={inputClass} placeholder="홍길동" />
+          {errors.name && <p className={errorClass}>{errors.name.message}</p>}
+        </div>
+
+        {/* Student number */}
+        <div>
+          <label className={labelClass}>학번</label>
+          <input {...register('studentNumber')} type="text" className={inputClass} placeholder="2024000000" />
+          {errors.studentNumber && <p className={errorClass}>{errors.studentNumber.message}</p>}
+        </div>
+
+        {/* Password */}
+        <div>
+          <label className={labelClass}>비밀번호</label>
+          <input {...register('password')} type="password" className={inputClass} placeholder="8자 이상" />
+          {errors.password && <p className={errorClass}>{errors.password.message}</p>}
+        </div>
+
+        {/* Password confirm */}
+        <div>
+          <label className={labelClass}>비밀번호 확인</label>
+          <input {...register('passwordConfirm')} type="password" className={inputClass} />
+          {errors.passwordConfirm && <p className={errorClass}>{errors.passwordConfirm.message}</p>}
+        </div>
+
+        {/* Server error */}
+        {errors.root && (
+          <p className="rounded-md bg-red-50 px-3 py-2 text-sm text-red-600">
+            {errors.root.message}
+          </p>
+        )}
+
+        <button
+          type="submit"
+          disabled={isSubmitting}
+          className="w-full rounded-md bg-primary-600 py-2.5 text-sm font-medium text-white hover:bg-primary-700 disabled:opacity-50"
+        >
+          {isSubmitting ? '가입 중...' : '가입하기'}
+        </button>
+      </form>
+
+      <p className="mt-6 text-center text-sm text-gray-500">
+        이미 계정이 있으신가요?{' '}
+        <Link to="/login" className="font-medium text-primary-600 hover:text-primary-700">
+          로그인
+        </Link>
+      </p>
+    </div>
+  )
+}

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -3,6 +3,7 @@ import { PageWrapper } from '@/components/layout/PageWrapper'
 import { RequireAuth } from '@/components/layout/RequireAuth'
 import Home from '@/pages/Home'
 import Login from '@/pages/Login'
+import SignUp from '@/pages/SignUp'
 import ProjectList from '@/pages/ProjectList'
 import ProjectDetail from '@/pages/ProjectDetail'
 import ProjectUpload from '@/pages/ProjectUpload'
@@ -21,6 +22,7 @@ const router = createBrowserRouter([
     children: [
       { index: true, element: <Home /> },
       { path: 'login', element: <Login /> },
+      { path: 'signup', element: <SignUp /> },
       { path: 'projects', element: <ProjectList /> },
       { path: 'projects/:id', element: <ProjectDetail /> },
 

--- a/frontend/src/types/user.ts
+++ b/frontend/src/types/user.ts
@@ -10,3 +10,10 @@ export interface LoginRequest {
   email: string
   password: string
 }
+
+export interface SignupRequest {
+  email: string
+  password: string
+  name: string
+  studentNumber: string
+}


### PR DESCRIPTION
## 관련 이슈

없음

---

## 변경 내용과 그 이유

백엔드 `/api/v1/auth/signup` 엔드포인트가 이미 구현되어 있으나 프론트엔드 회원가입 UI가 없어 테스트 계정을 curl/스크립트로만 생성해야 했습니다. UI를 구현하여 일반 사용자도 회원가입이 가능하도록 합니다.

### `frontend/src/types/user.ts`
- `SignupRequest` 인터페이스 추가 (`email`, `password`, `name`, `studentNumber`)

### `frontend/src/api/auth.ts`
- `signup()` 함수 추가 — POST `/api/v1/auth/signup`

### `frontend/src/pages/SignUp.tsx` (신규)
- zod 스키마로 클라이언트 유효성 검증 (이메일 형식, 비밀번호 8자 이상, 학번 필수, 비밀번호 확인 일치)
- 서버 에러(중복 이메일 등) 폼 상단 표시
- 회원가입 성공 시 `/login` 리다이렉트
- 이미 로그인된 경우 `/` 리다이렉트

### `frontend/src/router.tsx`
- `/signup` 경로 추가

### `frontend/src/pages/Login.tsx`
- 하단 "계정이 없으신가요? 회원가입" 링크 추가

---

## 메모 (선택)

- 회원가입 성공 후 자동 로그인은 미적용 — 명시적 로그인 유도
- 백엔드 `SignUpRequest`가 요구하는 `studentNumber` 필드 필수 포함
- `VITE_USE_MSW=false` 환경에서 테스트 필요