### PR TITLE
[REFACTOR] API 레이어 추상화 — ApiResponse<T> 공통 타입 적용 및 중복 제거

### DIFF
--- a/frontend/src/api/_adapters.ts
+++ b/frontend/src/api/_adapters.ts
@@ -1,0 +1,29 @@
+import type { BackendPage, BackendProjectResponse, PagedResponse, ProjectSummary } from '@/types/project'
+
+// Map backend semester string to frontend numeric value
+export const toSemesterNum = (s: string): 1 | 2 => (s === 'SECOND' ? 2 : 1)
+
+// Adapt backend ProjectResponse to the frontend ProjectSummary view model
+export const toSummary = (p: BackendProjectResponse): ProjectSummary => ({
+  id: p.id,
+  title: p.title,
+  summary: p.summary,
+  year: p.year,
+  semester: toSemesterNum(p.semester),
+  subjectName: p.domain ?? '',
+  teamName: p.authorName ?? '',
+  techStacks: p.techStacks,
+  tags: [],
+  status: 'APPROVED',   // backend does not expose status in list; default for display
+  viewCount: 0,
+  downloadCount: 0,
+  createdAt: p.createdAt,
+})
+
+// Backend paged response → frontend PagedResponse
+export const toPagedSummary = (page: BackendPage<BackendProjectResponse>): PagedResponse<ProjectSummary> => ({
+  items: page.content.map(toSummary),
+  total: page.totalElements,
+  page: page.number + 1,   // convert 0-based to 1-based
+  size: page.size,
+})

--- a/frontend/src/api/admin.ts
+++ b/frontend/src/api/admin.ts
@@ -1,26 +1,12 @@
 import { api } from './axiosInstance'
+import type { ApiResponse } from '@/types/api'
+import type { AuditLog, AdminStats } from '@/types/admin'
 import type { PagedResponse, ProjectSummary, Visibility } from '@/types/project'
-
-interface AuditLog {
-  id: number
-  action: string
-  targetId: number
-  actorId: number
-  timestamp: string
-}
-
-interface AdminStats {
-  totalProjects: number
-  pendingProjects: number
-  approvedThisMonth: number
-  downloadsThisMonth: number
-  topTags: { tag: string; count: number }[]
-}
 
 export const getPendingProjects = (params?: { page?: number; size?: number }) =>
   api
-    .get<PagedResponse<ProjectSummary>>('/api/admin/projects/pending', { params })
-    .then((r) => r.data)
+    .get<ApiResponse<PagedResponse<ProjectSummary>>>('/api/admin/projects/pending', { params })
+    .then((r) => r.data.data)
 
 export const approveProject = (id: number, visibility: Visibility) =>
   api.patch(`/api/admin/projects/${id}/approve`, { visibility })
@@ -31,7 +17,8 @@ export const rejectProject = (id: number, reason: string) =>
 export const requestRevision = (id: number, fields: string[]) =>
   api.patch(`/api/admin/projects/${id}/request-revision`, { fields })
 
-export const getStats = () => api.get<AdminStats>('/api/admin/stats').then((r) => r.data)
+export const getStats = () =>
+  api.get<ApiResponse<AdminStats>>('/api/admin/stats').then((r) => r.data.data)
 
 export const getAuditLogs = (params?: { page?: number; size?: number }) =>
-  api.get<PagedResponse<AuditLog>>('/api/admin/audit-logs', { params }).then((r) => r.data)
+  api.get<ApiResponse<PagedResponse<AuditLog>>>('/api/admin/audit-logs', { params }).then((r) => r.data.data)

--- a/frontend/src/api/auth.ts
+++ b/frontend/src/api/auth.ts
@@ -1,5 +1,6 @@
 import { api } from './axiosInstance'
 import { useAuthStore } from '@/store/authStore'
+import type { ApiResponse } from '@/types/api'
 import type { UserRole, LoginRequest, SignupRequest } from '@/types/user'
 
 // Decode JWT payload without verification (trust the server)
@@ -9,7 +10,7 @@ const decodeJwt = (token: string): Record<string, unknown> => {
 }
 
 export const login = async (data: LoginRequest): Promise<void> => {
-  const res = await api.post<{ data: { accessToken: string; refreshToken: string } }>(
+  const res = await api.post<ApiResponse<{ accessToken: string; refreshToken: string }>>(
     '/api/v1/auth/login',
     data,
   )

--- a/frontend/src/api/files.ts
+++ b/frontend/src/api/files.ts
@@ -1,9 +1,10 @@
 import { api } from './axiosInstance'
+import type { ApiResponse } from '@/types/api'
 import type { FileMetadata } from '@/types/file'
 
 export const uploadFile = (projectId: number | 'temp', formData: FormData) =>
   api
-    .post<{ data: FileMetadata }>(`/api/v1/files/projects/${projectId}`, formData, {
+    .post<ApiResponse<FileMetadata>>(`/api/v1/files/projects/${projectId}`, formData, {
       headers: { 'Content-Type': 'multipart/form-data' },
     })
     .then((r) => r.data.data)
@@ -13,5 +14,5 @@ export const deleteFile = (fileId: number) => api.delete(`/api/v1/files/${fileId
 // Backend returns FileResponse with a downloadUrl field directly (no separate /download sub-path)
 export const getDownloadUrl = (fileId: number) =>
   api
-    .get<{ data: { downloadUrl: string } }>(`/api/v1/files/${fileId}`)
+    .get<ApiResponse<{ downloadUrl: string }>>(`/api/v1/files/${fileId}`)
     .then((r) => r.data.data)

--- a/frontend/src/api/projects.ts
+++ b/frontend/src/api/projects.ts
@@ -1,51 +1,23 @@
 import { api } from './axiosInstance'
+import { toSummary, toPagedSummary } from './_adapters'
+import type { ApiResponse } from '@/types/api'
 import type {
   BackendPage,
   BackendProjectResponse,
-  PagedResponse,
   ProjectCreateRequest,
   ProjectDetail,
   ProjectListParams,
-  ProjectSummary,
   RecommendationResult,
 } from '@/types/project'
 
-// Map backend semester string to frontend numeric value
-const toSemesterNum = (s: string): 1 | 2 => (s === 'SECOND' ? 2 : 1)
-
-// Adapt backend ProjectResponse to the frontend ProjectSummary view model
-const toSummary = (p: BackendProjectResponse): ProjectSummary => ({
-  id: p.id,
-  title: p.title,
-  summary: p.summary,
-  year: p.year,
-  semester: toSemesterNum(p.semester),
-  subjectName: p.domain ?? '',
-  teamName: p.authorName ?? '',
-  techStacks: p.techStacks,
-  tags: [],
-  status: 'APPROVED',   // backend does not expose status in list; default for display
-  viewCount: 0,
-  downloadCount: 0,
-  createdAt: p.createdAt,
-})
-
-// Backend paged response → frontend PagedResponse
-const toPagedSummary = (page: BackendPage<BackendProjectResponse>): PagedResponse<ProjectSummary> => ({
-  items: page.content.map(toSummary),
-  total: page.totalElements,
-  page: page.number + 1,   // convert 0-based to 1-based
-  size: page.size,
-})
-
 export const getProjects = (params: ProjectListParams) =>
   api
-    .get<{ data: BackendPage<BackendProjectResponse> }>('/api/v1/projects', { params })
+    .get<ApiResponse<BackendPage<BackendProjectResponse>>>('/api/v1/projects', { params })
     .then((r) => toPagedSummary(r.data.data))
 
 export const getProjectDetail = (id: number) =>
   api
-    .get<{ data: BackendProjectResponse }>(`/api/v1/projects/${id}`)
+    .get<ApiResponse<BackendProjectResponse>>(`/api/v1/projects/${id}`)
     .then((r) => {
       const p = r.data.data
       const summary = toSummary(p)
@@ -61,7 +33,7 @@ export const getProjectDetail = (id: number) =>
 
 export const createProject = (data: ProjectCreateRequest) =>
   api
-    .post<{ data: BackendProjectResponse }>('/api/v1/projects', data)
+    .post<ApiResponse<BackendProjectResponse>>('/api/v1/projects', data)
     .then((r) => ({ projectId: r.data.data.id, status: 'APPROVED' }))
 
 export const updateProject = (id: number, data: Partial<ProjectCreateRequest>) =>
@@ -71,10 +43,10 @@ export const deleteProject = (id: number) => api.delete(`/api/v1/projects/${id}`
 
 export const getMyProjects = () =>
   api
-    .get<{ data: BackendProjectResponse[] }>('/api/v1/projects/my')
+    .get<ApiResponse<BackendProjectResponse[]>>('/api/v1/projects/my')
     .then((r) => r.data.data.map(toSummary))
 
 export const getRecommendations = (projectId: number) =>
   api
-    .get<{ data: RecommendationResult }>(`/api/v1/projects/${projectId}/recommendations`)
+    .get<ApiResponse<RecommendationResult>>(`/api/v1/projects/${projectId}/recommendations`)
     .then((r) => r.data.data)

--- a/frontend/src/api/search.ts
+++ b/frontend/src/api/search.ts
@@ -1,54 +1,20 @@
 import { api } from './axiosInstance'
 import axios from 'axios'
+import { toSummary, toPagedSummary } from './_adapters'
+import type { ApiResponse } from '@/types/api'
 import type { NaturalSearchResult } from '@/types/chat'
 import type {
   BackendPage,
   BackendProjectResponse,
-  PagedResponse,
+  KeywordSearchParams,
   ProjectSummary,
 } from '@/types/project'
-
-interface KeywordSearchParams {
-  keyword?: string
-  techStacks?: string[]
-  year?: number
-  semester?: string
-  difficulty?: string
-  page?: number
-  size?: number
-}
-
-const toSemesterNum = (s: string): 1 | 2 => (s === 'SECOND' ? 2 : 1)
-const toSummary = (p: BackendProjectResponse): ProjectSummary => ({
-  id: p.id,
-  title: p.title,
-  summary: p.summary,
-  year: p.year,
-  semester: toSemesterNum(p.semester),
-  subjectName: p.domain ?? '',
-  teamName: p.authorName ?? '',
-  techStacks: p.techStacks,
-  tags: [],
-  status: 'APPROVED',
-  viewCount: 0,
-  downloadCount: 0,
-  createdAt: p.createdAt,
-})
 
 // Backend search is exposed via GET /api/v1/projects?keyword=... (no dedicated /search endpoint)
 export const searchKeyword = (params: KeywordSearchParams) =>
   api
-    .get<{ data: BackendPage<BackendProjectResponse> }>('/api/v1/projects', { params })
-    .then((r) => {
-      const page = r.data.data
-      const result: PagedResponse<ProjectSummary> = {
-        items: page.content.map(toSummary),
-        total: page.totalElements,
-        page: page.number + 1,
-        size: page.size,
-      }
-      return result
-    })
+    .get<ApiResponse<BackendPage<BackendProjectResponse>>>('/api/v1/projects', { params })
+    .then((r) => toPagedSummary(r.data.data))
 
 // Backend recommend response shape
 interface BackendRecommendResult {
@@ -66,11 +32,11 @@ export interface NaturalSearchBackendResult {
 // Natural language recommendation via backend AI adapter
 // Fetches each recommended project by ID in parallel after getting the ID list
 export const searchNatural = async (query: string): Promise<NaturalSearchBackendResult> => {
-  const res = await api.post<{ data: BackendRecommendResult }>('/api/v1/projects/recommend', { query })
+  const res = await api.post<ApiResponse<BackendRecommendResult>>('/api/v1/projects/recommend', { query })
   const { answer, recommendedProjectIds, reasoning } = res.data.data
   const projects = await Promise.all(
     recommendedProjectIds.map((id) =>
-      api.get<{ data: BackendProjectResponse }>(`/api/v1/projects/${id}`).then((r) => toSummary(r.data.data)),
+      api.get<ApiResponse<BackendProjectResponse>>(`/api/v1/projects/${id}`).then((r) => toSummary(r.data.data)),
     ),
   )
   return { answer, reasoning, projects }

--- a/frontend/src/types/admin.ts
+++ b/frontend/src/types/admin.ts
@@ -1,0 +1,15 @@
+export interface AuditLog {
+  id: number
+  action: string
+  targetId: number
+  actorId: number
+  timestamp: string
+}
+
+export interface AdminStats {
+  totalProjects: number
+  pendingProjects: number
+  approvedThisMonth: number
+  downloadsThisMonth: number
+  topTags: { tag: string; count: number }[]
+}

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -1,0 +1,7 @@
+// Standard backend envelope — every endpoint wraps its payload in this shape
+export interface ApiResponse<T> {
+  success: boolean
+  message: string
+  data: T
+  errorCode: string | null
+}

--- a/frontend/src/types/project.ts
+++ b/frontend/src/types/project.ts
@@ -112,3 +112,14 @@ export interface RecommendationItem {
 export interface RecommendationResult {
   recommendations: RecommendationItem[]
 }
+
+export interface KeywordSearchParams {
+  keyword?: string
+  techStacks?: string[]
+  year?: number
+  semester?: string
+  difficulty?: string
+  domain?: string
+  page?: number
+  size?: number
+}


### PR DESCRIPTION
## 관련 이슈

없음 (5주차 코드 품질 개선 작업)

---

## 변경 내용과 그 이유

### 배경
기존 API 레이어에는 다음과 같은 문제가 있었습니다.
- 모든 API 함수의 응답 타입이 `{ data: T }` 인라인으로 반복 정의되어 있었고, 백엔드 공통 응답 구조(`success`, `message`, `errorCode`)가 타입에 반영되지 않았음
- `toSemesterNum()`, `toSummary()`, `toPagedSummary()` 어댑터 함수가 `projects.ts`와 `search.ts`에 동일한 코드로 중복 정의되어 있었음
- `AuditLog`, `AdminStats`, `KeywordSearchParams` 등 도메인 타입이 API 파일 내부에 로컬로 정의되어 있었음
- `admin.ts`만 응답을 `r.data`로 처리하고 나머지는 `r.data.data`를 쓰는 불일치 존재

### 변경 사항

**신규 파일**
- `frontend/src/types/api.ts` — `ApiResponse<T>` 공통 래퍼 인터페이스 정의
- `frontend/src/types/admin.ts` — `AuditLog`, `AdminStats` 인터페이스 분리
- `frontend/src/api/_adapters.ts` — `toSemesterNum`, `toSummary`, `toPagedSummary` 어댑터 함수 통합 모듈

**수정 파일**
- `frontend/src/types/project.ts` — `KeywordSearchParams` 인터페이스 추가 (search.ts에서 이동, `domain` 파라미터 포함)
- `frontend/src/api/projects.ts` — 로컬 어댑터 함수 제거, `_adapters` import, `ApiResponse<T>` 적용
- `frontend/src/api/search.ts` — 중복 어댑터 함수 제거, `KeywordSearchParams` import, `ApiResponse<T>` 적용
- `frontend/src/api/files.ts` — `ApiResponse<T>` 적용
- `frontend/src/api/auth.ts` — `ApiResponse<T>` 적용
- `frontend/src/api/admin.ts` — 로컬 타입 제거 후 `types/admin` import, `r.data` → `r.data.data` 일관성 수정

---

## 메모 (선택)

- `admin.ts`의 엔드포인트 경로(`/api/admin/...`)가 다른 파일(`/api/v1/...`)과 다른 것은 백엔드 설계에 따른 것으로 의도적으로 유지함
- `_adapters.ts`의 `status: 'APPROVED'` 기본값은 백엔드 목록 응답에 status 필드가 없기 때문이며 추후 백엔드 API 보완 시 수정 예정