### PR TITLE
[FEAT] 필터 검색 연동 및 채팅 히스토리 localStorage 유지

### DIFF
--- a/backend/src/main/java/com/ctrl/cbnu_archive/project/domain/Project.java
+++ b/backend/src/main/java/com/ctrl/cbnu_archive/project/domain/Project.java
@@ -48,6 +48,8 @@ public class Project extends BaseTimeEntity {
     private String semester;
     private String difficulty;
     private String domain;
+    @Column(name = "is_team")
+    private Boolean isTeam;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "author_id", nullable = false)
@@ -66,6 +68,7 @@ public class Project extends BaseTimeEntity {
                     String semester,
                     String difficulty,
                     String domain,
+                    Boolean isTeam,
                     User author) {
         this.title = Objects.requireNonNull(title, "title must not be null");
         this.summary = summary;
@@ -78,6 +81,7 @@ public class Project extends BaseTimeEntity {
         this.semester = semester;
         this.difficulty = difficulty;
         this.domain = domain;
+        this.isTeam = isTeam;
         this.author = Objects.requireNonNull(author, "author must not be null");
     }
 
@@ -90,8 +94,9 @@ public class Project extends BaseTimeEntity {
                                  String semester,
                                  String difficulty,
                                  String domain,
+                                 Boolean isTeam,
                                  User author) {
-        return new Project(title, summary, description, readme, techStacks, year, semester, difficulty, domain, author);
+        return new Project(title, summary, description, readme, techStacks, year, semester, difficulty, domain, isTeam, author);
     }
 
     public Long getId() {
@@ -132,6 +137,10 @@ public class Project extends BaseTimeEntity {
 
     public String getDomain() {
         return domain;
+    }
+
+    public Boolean getIsTeam() {
+        return isTeam;
     }
 
     public Long getAuthorId() {

--- a/backend/src/main/java/com/ctrl/cbnu_archive/project/dto/ProjectCreateRequest.java
+++ b/backend/src/main/java/com/ctrl/cbnu_archive/project/dto/ProjectCreateRequest.java
@@ -12,7 +12,8 @@ public record ProjectCreateRequest(
         Integer year,
         String semester,
         String difficulty,
-        String domain
+        String domain,
+        Boolean isTeam
 ) {
     public Project toEntity(User author) {
         return Project.create(
@@ -25,6 +26,7 @@ public record ProjectCreateRequest(
                 semester,
                 difficulty,
                 domain,
+                isTeam,
                 author
         );
     }

--- a/backend/src/main/java/com/ctrl/cbnu_archive/project/dto/SearchRequest.java
+++ b/backend/src/main/java/com/ctrl/cbnu_archive/project/dto/SearchRequest.java
@@ -10,10 +10,11 @@ public record SearchRequest(
         String semester,
         String difficulty,
         String domain,
+        Boolean isTeam,
         int page,
         int size
 ) {
     public SearchQuery toSearchQuery() {
-        return new SearchQuery(keyword, techStacks, year, semester, difficulty, domain, page, size);
+        return new SearchQuery(keyword, techStacks, year, semester, difficulty, domain, isTeam, page, size);
     }
 }

--- a/backend/src/main/java/com/ctrl/cbnu_archive/project/service/ProjectService.java
+++ b/backend/src/main/java/com/ctrl/cbnu_archive/project/service/ProjectService.java
@@ -156,7 +156,8 @@ public class ProjectService {
                 project.getYear(),
                 project.getSemester(),
                 project.getDifficulty(),
-                project.getDomain()
+                project.getDomain(),
+                project.getIsTeam()
         );
         String embeddingText = buildEmbeddingText(project);
         eventPublisher.publishEvent(new ProjectIndexEvent(project.getId(), indexDocument, embeddingText));

--- a/backend/src/main/java/com/ctrl/cbnu_archive/project/service/adapter/mock/MockProjectSearchAdapter.java
+++ b/backend/src/main/java/com/ctrl/cbnu_archive/project/service/adapter/mock/MockProjectSearchAdapter.java
@@ -46,9 +46,10 @@ public class MockProjectSearchAdapter implements ProjectSearchPort {
                 .filter(doc -> matchesKeyword(doc, query.keyword()))
                 .filter(doc -> matchesListFilter(doc.techStacks(), query.techStacks()))
                 .filter(doc -> matchesValue(doc.year(), query.year()))
-                .filter(doc -> matchesValue(doc.semester(), query.semester()))
+                .filter(doc -> matchesSemester(doc.semester(), query.semester()))
                 .filter(doc -> matchesValue(doc.difficulty(), query.difficulty()))
                 .filter(doc -> matchesValue(doc.domain(), query.domain()))
+                .filter(doc -> matchesValue(doc.isTeam(), query.isTeam()))
                 .map(doc -> new ProjectSearchResult(
                         doc.projectId(),
                         doc.title(),
@@ -58,6 +59,7 @@ public class MockProjectSearchAdapter implements ProjectSearchPort {
                         doc.semester(),
                         doc.difficulty(),
                         doc.domain(),
+                        doc.isTeam(),
                         1.0f
                 ))
                 .collect(Collectors.toList());
@@ -102,5 +104,20 @@ public class MockProjectSearchAdapter implements ProjectSearchPort {
             return true;
         }
         return expected.equals(actual);
+    }
+
+    // Normalize semester to canonical form so "1"/"FIRST" and "2"/"SECOND" both match
+    private String normalizeSemester(String s) {
+        if (s == null) return null;
+        return switch (s.toUpperCase()) {
+            case "1", "FIRST" -> "FIRST";
+            case "2", "SECOND" -> "SECOND";
+            default -> s.toUpperCase();
+        };
+    }
+
+    private boolean matchesSemester(String actual, String expected) {
+        if (expected == null) return true;
+        return normalizeSemester(expected).equals(normalizeSemester(actual));
     }
 }

--- a/backend/src/main/java/com/ctrl/cbnu_archive/project/service/port/ProjectIndexDocument.java
+++ b/backend/src/main/java/com/ctrl/cbnu_archive/project/service/port/ProjectIndexDocument.java
@@ -11,6 +11,7 @@ public record ProjectIndexDocument(
         Integer year,
         String semester,
         String difficulty,
-        String domain
+        String domain,
+        Boolean isTeam
 ) {
 }

--- a/backend/src/main/java/com/ctrl/cbnu_archive/project/service/port/ProjectSearchResult.java
+++ b/backend/src/main/java/com/ctrl/cbnu_archive/project/service/port/ProjectSearchResult.java
@@ -11,6 +11,7 @@ public record ProjectSearchResult(
         String semester,
         String difficulty,
         String domain,
+        Boolean isTeam,
         float score
 ) {
 }

--- a/backend/src/main/java/com/ctrl/cbnu_archive/project/service/port/SearchQuery.java
+++ b/backend/src/main/java/com/ctrl/cbnu_archive/project/service/port/SearchQuery.java
@@ -9,6 +9,7 @@ public record SearchQuery(
         String semester,
         String difficulty,
         String domain,
+        Boolean isTeam,
         int page,
         int size
 ) {

--- a/frontend/src/api/axiosInstance.ts
+++ b/frontend/src/api/axiosInstance.ts
@@ -6,6 +6,8 @@ export const api = axios.create({
   baseURL: import.meta.env.VITE_API_BASE_URL ?? '',
   withCredentials: true,
   timeout: 10000,
+  // Spring @ModelAttribute expects repeated params (key=v1&key=v2), not bracket notation (key[]=v1)
+  paramsSerializer: { indexes: null },
 })
 
 api.interceptors.request.use((config) => {

--- a/frontend/src/pages/ProjectList.tsx
+++ b/frontend/src/pages/ProjectList.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useEffect } from 'react'
+import { useState, useCallback, useEffect, useRef } from 'react'
 import { SearchBar } from '@/components/search/SearchBar'
 import { FilterPanel } from '@/components/search/FilterPanel'
 import { ProjectCard } from '@/components/project/ProjectCard'
@@ -8,7 +8,7 @@ import type { NaturalSearchBackendResult } from '@/api/search'
 import type { ProjectSummary } from '@/types/project'
 
 export default function ProjectList() {
-  const { keyword, searchType, filters } = useSearchStore()
+  const { keyword, searchType, filters, sort } = useSearchStore()
 
   const [isLoading, setIsLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
@@ -16,43 +16,66 @@ export default function ProjectList() {
   // Natural search state
   const [naturalResult, setNaturalResult] = useState<NaturalSearchBackendResult | null>(null)
 
-  // Keyword search state (backend stub); pre-populated on mount
+  // Keyword search results
   const [keywordProjects, setKeywordProjects] = useState<ProjectSummary[]>([])
 
-  // Load all projects on first render so the page isn't empty
-  useEffect(() => {
-    searchKeyword({ keyword: '', page: 0, size: 20 })
-      .then((page) => setKeywordProjects(page.items ?? []))
-      .catch(() => {/* silently skip if backend/MSW not available */})
-  }, [])
+  // Ref so filter-change effects always use the latest keyword without re-subscribing
+  const keywordRef = useRef(keyword)
+  keywordRef.current = keyword
 
-  const handleSearch = useCallback(async () => {
-    // Natural search always requires a query
-    if (searchType === 'natural' && !keyword.trim()) return
+  // Execute keyword search — reused by filter effect and handleSearch
+  const execKeywordSearch = useCallback(async (kw: string) => {
     setIsLoading(true)
     setError(null)
     setNaturalResult(null)
-    setKeywordProjects([])
-
     try {
-      if (searchType === 'natural') {
-        const result = await searchNatural(keyword)
-        setNaturalResult(result)
-      } else {
-        // Keyword search through backend; returns empty list until backend is ready
-        const page = await searchKeyword({
-          keyword: keyword,
-          page: 0,
-          size: 20,
-        })
-        setKeywordProjects(page.items ?? [])
-      }
-    } catch (e) {
+      const result = await searchKeyword({
+        keyword: kw || undefined,
+        // Map array filters to single values that the current backend accepts
+        year: filters.years[0],
+        semester: filters.semester === 1 ? 'FIRST' : filters.semester === 2 ? 'SECOND' : undefined,
+        domain: filters.domains[0],
+        techStacks: filters.techStacks.length > 0 ? filters.techStacks : undefined,
+        sort,
+        page: 0,
+        size: 20,
+      })
+      setKeywordProjects(result.items ?? [])
+    } catch {
       setError('검색 중 오류가 발생했습니다. 서버 상태를 확인해주세요.')
     } finally {
       setIsLoading(false)
     }
-  }, [keyword, searchType, filters])
+  }, [filters, sort])
+
+  // On mount and whenever filters/sort change, re-run keyword search automatically
+  // keywordRef ensures we always use the latest keyword without adding it as a dep
+  useEffect(() => {
+    if (searchType !== 'keyword') return
+    execKeywordSearch(keywordRef.current)
+  }, [filters, sort, searchType, execKeywordSearch])
+
+  const handleSearch = useCallback(async () => {
+    if (searchType === 'natural') {
+      // Natural search always requires a query
+      if (!keyword.trim()) return
+      setIsLoading(true)
+      setError(null)
+      setNaturalResult(null)
+      setKeywordProjects([])
+      try {
+        const result = await searchNatural(keyword)
+        setNaturalResult(result)
+      } catch {
+        setError('검색 중 오류가 발생했습니다. 서버 상태를 확인해주세요.')
+      } finally {
+        setIsLoading(false)
+      }
+    } else {
+      // Keyword search: run immediately with current keyword + active filters
+      execKeywordSearch(keyword)
+    }
+  }, [keyword, searchType, execKeywordSearch])
 
   // Derive display list from whichever search mode is active
   const naturalItems = naturalResult?.projects ?? []

--- a/frontend/src/pages/ProjectList.tsx
+++ b/frontend/src/pages/ProjectList.tsx
@@ -36,6 +36,8 @@ export default function ProjectList() {
         semester: filters.semester === 1 ? 'FIRST' : filters.semester === 2 ? 'SECOND' : undefined,
         domain: filters.domains[0],
         techStacks: filters.techStacks.length > 0 ? filters.techStacks : undefined,
+        // null means "no filter", true/false means team/individual
+        isTeam: filters.isTeam ?? undefined,
         sort,
         page: 0,
         size: 20,

--- a/frontend/src/store/chatStore.ts
+++ b/frontend/src/store/chatStore.ts
@@ -1,4 +1,5 @@
 import { create } from 'zustand'
+import { persist } from 'zustand/middleware'
 import type { ChatMessage } from '@/types/chat'
 
 interface ChatState {
@@ -11,12 +12,22 @@ interface ChatState {
   resetSession: () => void
 }
 
-export const useChatStore = create<ChatState>((set) => ({
-  sessionId: null,
-  messages: [],
-  isLoading: false,
-  setSessionId: (sessionId) => set({ sessionId }),
-  addMessage: (message) => set((state) => ({ messages: [...state.messages, message] })),
-  setLoading: (isLoading) => set({ isLoading }),
-  resetSession: () => set({ sessionId: null, messages: [], isLoading: false }),
-}))
+export const useChatStore = create<ChatState>()(
+  persist(
+    (set) => ({
+      sessionId: null,
+      messages: [],
+      isLoading: false,
+      setSessionId: (sessionId) => set({ sessionId }),
+      addMessage: (message) => set((state) => ({ messages: [...state.messages, message] })),
+      setLoading: (isLoading) => set({ isLoading }),
+      // isLoading is transient — always reset to false on restore
+      resetSession: () => set({ sessionId: null, messages: [], isLoading: false }),
+    }),
+    {
+      name: 'cbnu-chat-history',
+      // Only persist session data, not transient loading state
+      partialize: (state) => ({ sessionId: state.sessionId, messages: state.messages }),
+    },
+  ),
+)

--- a/frontend/src/types/project.ts
+++ b/frontend/src/types/project.ts
@@ -120,6 +120,7 @@ export interface KeywordSearchParams {
   semester?: string
   difficulty?: string
   domain?: string
+  sort?: SortOption
   page?: number
   size?: number
 }

--- a/frontend/src/types/project.ts
+++ b/frontend/src/types/project.ts
@@ -120,6 +120,7 @@ export interface KeywordSearchParams {
   semester?: string
   difficulty?: string
   domain?: string
+  isTeam?: boolean
   sort?: SortOption
   page?: number
   size?: number


### PR DESCRIPTION
## 관련 이슈

없음 (6주차 기능 구현)

---

## 변경 내용과 그 이유

### 1. FilterPanel → `searchKeyword()` 연결

**배경**: 기존 `ProjectList.tsx`의 키워드 검색은 `keyword`만 전달하고 FilterPanel의 연도·학기·도메인·기술스택·정렬 필터를 무시했음. 필터를 변경해도 검색 결과가 갱신되지 않는 문제.

**변경 사항**:
- `types/project.ts`의 `KeywordSearchParams`에 `sort?: SortOption` 추가
- `ProjectList.tsx`:
  - `execKeywordSearch(kw)` 헬퍼 함수 추출 — 현재 필터·정렬 상태를 포함하여 API 호출
  - `useRef` 패턴으로 `keywordRef` 유지 — 필터 변경 effect가 최신 keyword를 스테일 클로저 없이 읽음
  - `useEffect([filters, sort, searchType, execKeywordSearch])` 추가 — 필터/정렬 변경 시 자동 재검색 (마운트 시 초기 로드도 겸함)
  - 기존 별도 초기 로드 `useEffect` 제거 (위 effect가 마운트 시에도 실행되므로 중복)
  - `handleSearch`를 단순화: 키워드 검색은 `execKeywordSearch(keyword)`, AI 자연어 검색은 기존 로직 유지

**필터-API 매핑** (현재 백엔드 단일값 제약 반영):
| Store 필드 | API 파라미터 |
|---|---|
| `filters.years[0]` | `year` (단일, 첫 번째 선택값) |
| `filters.semester` | `semester` (`'FIRST'`/`'SECOND'`) |
| `filters.domains[0]` | `domain` (단일) |
| `filters.techStacks[]` | `techStacks` (배열) |
| `sort` | `sort` |

### 2. `chatStore` localStorage 유지

**배경**: 페이지 이동/새로고침 시 AI 채팅 히스토리가 초기화되는 문제.

**변경 사항**:
- `store/chatStore.ts`에 Zustand `persist` 미들웨어 적용
- key: `cbnu-chat-history`
- `partialize`로 `isLoading`(트랜지언트) 제외, `sessionId`·`messages`만 저장

---

## 메모 (선택)

- 필터의 `years`, `domains`는 배열이지만 현재 백엔드가 단일값만 받아 첫 번째 값만 전달. 백엔드에서 배열 쿼리 파라미터를 지원하면 `KeywordSearchParams`를 확장 예정
- `resetSession()`은 localStorage도 함께 초기화됨 (Zustand persist 기본 동작)