### PR TITLE
[FEAT] 프론트엔드 연동 누락 API 일괄 구현

### DIFF
--- a/backend/src/main/java/com/ctrl/cbnu_archive/auth/controller/AdminUserController.java
+++ b/backend/src/main/java/com/ctrl/cbnu_archive/auth/controller/AdminUserController.java
@@ -1,0 +1,58 @@
+package com.ctrl.cbnu_archive.auth.controller;
+
+import com.ctrl.cbnu_archive.auth.dto.RejectUserRequest;
+import com.ctrl.cbnu_archive.auth.dto.UserResponse;
+import com.ctrl.cbnu_archive.auth.service.UserService;
+import com.ctrl.cbnu_archive.global.response.ApiResponse;
+import com.ctrl.cbnu_archive.global.security.jwt.CustomUserDetails;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/admin/users")
+@PreAuthorize("hasRole('ADMIN')")
+@Tag(name = "Admin User", description = "관리자 회원 관리 API")
+public class AdminUserController {
+
+    private final UserService userService;
+
+    public AdminUserController(UserService userService) {
+        this.userService = userService;
+    }
+
+    @Operation(summary = "가입 승인 대기 목록 조회")
+    @GetMapping("/pending")
+    public ApiResponse<List<UserResponse>> getPendingUsers() {
+        return ApiResponse.success(userService.getPendingUsers());
+    }
+
+    @Operation(summary = "회원 승인")
+    @PostMapping("/{userId}/approve")
+    public ApiResponse<UserResponse> approveUser(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @PathVariable Long userId
+    ) {
+        return ApiResponse.success(userService.approveUser(userId, userDetails.getId()));
+    }
+
+    @Operation(summary = "회원 거절")
+    @PostMapping("/{userId}/reject")
+    public ApiResponse<Void> rejectUser(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @PathVariable Long userId,
+            @RequestBody(required = false) RejectUserRequest request
+    ) {
+        String reason = request != null ? request.reason() : null;
+        userService.rejectUser(userId, reason, userDetails.getId());
+        return ApiResponse.success(null);
+    }
+}

--- a/backend/src/main/java/com/ctrl/cbnu_archive/auth/domain/User.java
+++ b/backend/src/main/java/com/ctrl/cbnu_archive/auth/domain/User.java
@@ -35,6 +35,10 @@ public class User extends BaseTimeEntity {
     @Column(nullable = false)
     private UserRole role = UserRole.USER;
 
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private UserStatus status = UserStatus.PENDING;
+
     protected User() {
     }
 
@@ -44,6 +48,7 @@ public class User extends BaseTimeEntity {
         this.name = Objects.requireNonNull(name, "name must not be null");
         this.studentNumber = studentNumber;
         this.role = role == null ? UserRole.USER : role;
+        this.status = (this.role == UserRole.ADMIN) ? UserStatus.ACTIVE : UserStatus.PENDING;
     }
 
     public static User create(String email, String password, String name, String studentNumber) {
@@ -76,6 +81,18 @@ public class User extends BaseTimeEntity {
 
     public UserRole getRole() {
         return role;
+    }
+
+    public UserStatus getStatus() {
+        return status;
+    }
+
+    public void activate() {
+        this.status = UserStatus.ACTIVE;
+    }
+
+    public void rejectUser() {
+        this.status = UserStatus.REJECTED;
     }
 
     public void updatePassword(String encodedPassword) {

--- a/backend/src/main/java/com/ctrl/cbnu_archive/auth/domain/UserStatus.java
+++ b/backend/src/main/java/com/ctrl/cbnu_archive/auth/domain/UserStatus.java
@@ -1,0 +1,7 @@
+package com.ctrl.cbnu_archive.auth.domain;
+
+public enum UserStatus {
+    PENDING,
+    ACTIVE,
+    REJECTED
+}

--- a/backend/src/main/java/com/ctrl/cbnu_archive/auth/dto/RejectUserRequest.java
+++ b/backend/src/main/java/com/ctrl/cbnu_archive/auth/dto/RejectUserRequest.java
@@ -1,0 +1,4 @@
+package com.ctrl.cbnu_archive.auth.dto;
+
+public record RejectUserRequest(String reason) {
+}

--- a/backend/src/main/java/com/ctrl/cbnu_archive/auth/dto/UserResponse.java
+++ b/backend/src/main/java/com/ctrl/cbnu_archive/auth/dto/UserResponse.java
@@ -2,13 +2,15 @@ package com.ctrl.cbnu_archive.auth.dto;
 
 import com.ctrl.cbnu_archive.auth.domain.User;
 import com.ctrl.cbnu_archive.auth.domain.UserRole;
+import com.ctrl.cbnu_archive.auth.domain.UserStatus;
 
 public record UserResponse(
         Long id,
         String email,
         String name,
         String studentNumber,
-        UserRole role
+        UserRole role,
+        UserStatus status
 ) {
     public static UserResponse fromEntity(User user) {
         return new UserResponse(
@@ -16,7 +18,8 @@ public record UserResponse(
                 user.getEmail(),
                 user.getName(),
                 user.getStudentNumber(),
-                user.getRole()
+                user.getRole(),
+                user.getStatus()
         );
     }
 }

--- a/backend/src/main/java/com/ctrl/cbnu_archive/auth/repository/UserRepository.java
+++ b/backend/src/main/java/com/ctrl/cbnu_archive/auth/repository/UserRepository.java
@@ -1,6 +1,8 @@
 package com.ctrl.cbnu_archive.auth.repository;
 
 import com.ctrl.cbnu_archive.auth.domain.User;
+import com.ctrl.cbnu_archive.auth.domain.UserStatus;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
@@ -10,4 +12,5 @@ public interface UserRepository extends JpaRepository<User, Long> {
     boolean existsByEmail(String email);
     Optional<User> findByEmail(String email);
     Optional<User> findByStudentNumber(String studentNumber);
+    List<User> findByStatus(UserStatus status);
 }

--- a/backend/src/main/java/com/ctrl/cbnu_archive/auth/service/AuthService.java
+++ b/backend/src/main/java/com/ctrl/cbnu_archive/auth/service/AuthService.java
@@ -1,6 +1,7 @@
 package com.ctrl.cbnu_archive.auth.service;
 
 import com.ctrl.cbnu_archive.auth.domain.User;
+import com.ctrl.cbnu_archive.auth.domain.UserStatus;
 import com.ctrl.cbnu_archive.auth.dto.LoginRequest;
 import com.ctrl.cbnu_archive.auth.dto.SignUpRequest;
 import com.ctrl.cbnu_archive.auth.dto.TokenResponse;
@@ -47,6 +48,9 @@ public class AuthService {
                 .orElseThrow(() -> new AuthException(ErrorCode.USER_NOT_FOUND));
         if (!passwordEncoder.matches(request.password(), user.getPassword())) {
             throw new AuthException(ErrorCode.INVALID_INPUT, "이메일 또는 비밀번호가 일치하지 않습니다.");
+        }
+        if (user.getStatus() != UserStatus.ACTIVE) {
+            throw new AuthException(ErrorCode.USER_NOT_ACTIVE);
         }
         String accessToken = jwtTokenProvider.generateAccessToken(user.getId(), user.getEmail(), user.getRole());
         String refreshToken = jwtTokenProvider.generateRefreshToken(user.getId());

--- a/backend/src/main/java/com/ctrl/cbnu_archive/auth/service/UserService.java
+++ b/backend/src/main/java/com/ctrl/cbnu_archive/auth/service/UserService.java
@@ -1,15 +1,20 @@
 package com.ctrl.cbnu_archive.auth.service;
 
 import com.ctrl.cbnu_archive.auth.domain.User;
+import com.ctrl.cbnu_archive.auth.domain.UserStatus;
 import com.ctrl.cbnu_archive.auth.dto.PasswordChangeRequest;
 import com.ctrl.cbnu_archive.auth.dto.UserResponse;
 import com.ctrl.cbnu_archive.auth.dto.UserUpdateRequest;
 import com.ctrl.cbnu_archive.auth.exception.AuthException;
 import com.ctrl.cbnu_archive.auth.repository.UserRepository;
+import com.ctrl.cbnu_archive.global.domain.AuditLog;
 import com.ctrl.cbnu_archive.global.exception.ErrorCode;
+import com.ctrl.cbnu_archive.global.repository.AuditLogRepository;
 import com.ctrl.cbnu_archive.project.dto.ProjectResponse;
 import com.ctrl.cbnu_archive.project.mapper.ProjectMapper;
 import com.ctrl.cbnu_archive.project.repository.ProjectRepository;
+import java.util.List;
+import java.util.stream.Collectors;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.security.crypto.password.PasswordEncoder;
@@ -23,13 +28,16 @@ public class UserService {
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
     private final ProjectRepository projectRepository;
+    private final AuditLogRepository auditLogRepository;
 
     public UserService(UserRepository userRepository,
                        PasswordEncoder passwordEncoder,
-                       ProjectRepository projectRepository) {
+                       ProjectRepository projectRepository,
+                       AuditLogRepository auditLogRepository) {
         this.userRepository = userRepository;
         this.passwordEncoder = passwordEncoder;
         this.projectRepository = projectRepository;
+        this.auditLogRepository = auditLogRepository;
     }
 
     public UserResponse getMyInfo(Long userId) {
@@ -56,6 +64,27 @@ public class UserService {
     public Page<ProjectResponse> getMyProjects(Long userId, Pageable pageable) {
         return projectRepository.findByAuthorId(userId, pageable)
                 .map(ProjectMapper::toResponse);
+    }
+
+    public List<UserResponse> getPendingUsers() {
+        return userRepository.findByStatus(UserStatus.PENDING).stream()
+                .map(UserResponse::fromEntity)
+                .collect(Collectors.toList());
+    }
+
+    public UserResponse approveUser(Long userId, Long adminUserId) {
+        User user = loadUser(userId);
+        user.activate();
+        User saved = userRepository.save(user);
+        auditLogRepository.save(AuditLog.of(adminUserId, "APPROVE_USER", "USER", userId, null));
+        return UserResponse.fromEntity(saved);
+    }
+
+    public void rejectUser(Long userId, String reason, Long adminUserId) {
+        User user = loadUser(userId);
+        user.rejectUser();
+        userRepository.save(user);
+        auditLogRepository.save(AuditLog.of(adminUserId, "REJECT_USER", "USER", userId, reason));
     }
 
     private User loadUser(Long userId) {

--- a/backend/src/main/java/com/ctrl/cbnu_archive/file/controller/FileController.java
+++ b/backend/src/main/java/com/ctrl/cbnu_archive/file/controller/FileController.java
@@ -7,8 +7,14 @@ import com.ctrl.cbnu_archive.global.response.ApiResponse;
 import com.ctrl.cbnu_archive.global.security.jwt.CustomUserDetails;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import java.io.InputStream;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
+import org.springframework.core.io.InputStreamResource;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -66,5 +72,21 @@ public class FileController {
     ) {
         fileService.deleteFile(fileId, userDetails.getId(), userDetails.getAuthorities().stream().anyMatch(auth -> auth.getAuthority().equals("ROLE_ADMIN")));
         return ApiResponse.success(null);
+    }
+
+    @Operation(summary = "파일 다운로드", description = "파일 바이트를 직접 스트리밍합니다. 인증 필수.")
+    @GetMapping("/{fileId}/download")
+    public ResponseEntity<InputStreamResource> downloadFile(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @PathVariable Long fileId
+    ) {
+        boolean isAdmin = userDetails.getAuthorities().stream().anyMatch(auth -> auth.getAuthority().equals("ROLE_ADMIN"));
+        InputStream is = fileService.downloadFileStream(fileId, userDetails.getId(), isAdmin);
+        String filename = fileService.getOriginalFilename(fileId);
+        String encodedFilename = URLEncoder.encode(filename, StandardCharsets.UTF_8).replace("+", "%20");
+        return ResponseEntity.ok()
+                .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename*=UTF-8''" + encodedFilename)
+                .contentType(MediaType.APPLICATION_OCTET_STREAM)
+                .body(new InputStreamResource(is));
     }
 }

--- a/backend/src/main/java/com/ctrl/cbnu_archive/file/service/FileService.java
+++ b/backend/src/main/java/com/ctrl/cbnu_archive/file/service/FileService.java
@@ -14,6 +14,7 @@ import com.ctrl.cbnu_archive.project.domain.Project;
 import com.ctrl.cbnu_archive.project.exception.ProjectException;
 import com.ctrl.cbnu_archive.project.repository.ProjectRepository;
 import java.io.IOException;
+import java.io.InputStream;
 import java.time.Duration;
 import java.util.List;
 import java.util.Objects;
@@ -92,6 +93,24 @@ public class FileService {
         validateProjectAccess(projectFile.getProjectId(), currentUserId, isAdmin);
         fileStoragePort.delete(projectFile.getStorageKey());
         fileRepository.delete(projectFile);
+    }
+
+    public InputStream downloadFileStream(Long fileId, Long currentUserId, boolean isAdmin) {
+        Objects.requireNonNull(fileId, "fileId must not be null");
+        ProjectFile projectFile = fileRepository.findById(fileId)
+                .orElseThrow(() -> new FileException(ErrorCode.FILE_NOT_FOUND, "파일을 찾을 수 없습니다."));
+        validateProjectAccess(projectFile.getProjectId(), currentUserId, isAdmin);
+        try {
+            return fileStoragePort.download(projectFile.getStorageKey());
+        } catch (IllegalArgumentException e) {
+            throw new FileException(ErrorCode.FILE_NOT_FOUND, "파일 데이터를 찾을 수 없습니다.");
+        }
+    }
+
+    public String getOriginalFilename(Long fileId) {
+        return fileRepository.findById(fileId)
+                .orElseThrow(() -> new FileException(ErrorCode.FILE_NOT_FOUND, "파일을 찾을 수 없습니다."))
+                .getFileName();
     }
 
     private Project validateProjectAccess(Long projectId, Long currentUserId, boolean isAdmin) {

--- a/backend/src/main/java/com/ctrl/cbnu_archive/global/config/SecurityConfig.java
+++ b/backend/src/main/java/com/ctrl/cbnu_archive/global/config/SecurityConfig.java
@@ -44,8 +44,11 @@ public class SecurityConfig {
                 .authorizeHttpRequests(authorize -> authorize
                         .requestMatchers("/api/v1/auth/logout").authenticated()
                         .requestMatchers("/api/v1/auth/signup", "/api/v1/auth/login", "/api/v1/auth/reissue", "/swagger-ui/**", "/v3/api-docs/**", "/swagger-ui.html", "/h2-console/**").permitAll()
-                        .requestMatchers(HttpMethod.GET, "/api/v1/projects/**").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/api/v1/tech-stacks").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/api/v1/projects", "/api/v1/projects/{id}").permitAll()
                         .requestMatchers(HttpMethod.POST, "/api/v1/projects/recommend").permitAll()
+                        .requestMatchers(HttpMethod.POST, "/api/v1/search/natural").permitAll()
+                        .requestMatchers("/api/v1/admin/**").hasRole("ADMIN")
                         .requestMatchers("/api/v1/files/**").authenticated()
                         .requestMatchers("/api/v1/projects/**").authenticated()
                         .anyRequest().authenticated()

--- a/backend/src/main/java/com/ctrl/cbnu_archive/global/domain/AuditLog.java
+++ b/backend/src/main/java/com/ctrl/cbnu_archive/global/domain/AuditLog.java
@@ -1,0 +1,56 @@
+package com.ctrl.cbnu_archive.global.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "audit_logs")
+public class AuditLog {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private Long actorUserId;
+
+    @Column(nullable = false)
+    private String action;
+
+    private String entityType;
+    private Long entityId;
+
+    @Column(length = 1000)
+    private String detail;
+
+    @Column(nullable = false)
+    private LocalDateTime createdAt;
+
+    protected AuditLog() {
+    }
+
+    private AuditLog(Long actorUserId, String action, String entityType, Long entityId, String detail) {
+        this.actorUserId = actorUserId;
+        this.action = action;
+        this.entityType = entityType;
+        this.entityId = entityId;
+        this.detail = detail;
+        this.createdAt = LocalDateTime.now();
+    }
+
+    public static AuditLog of(Long actorUserId, String action, String entityType, Long entityId, String detail) {
+        return new AuditLog(actorUserId, action, entityType, entityId, detail);
+    }
+
+    public Long getId() { return id; }
+    public Long getActorUserId() { return actorUserId; }
+    public String getAction() { return action; }
+    public String getEntityType() { return entityType; }
+    public Long getEntityId() { return entityId; }
+    public String getDetail() { return detail; }
+    public LocalDateTime getCreatedAt() { return createdAt; }
+}

--- a/backend/src/main/java/com/ctrl/cbnu_archive/global/dto/AuditLogResponse.java
+++ b/backend/src/main/java/com/ctrl/cbnu_archive/global/dto/AuditLogResponse.java
@@ -1,0 +1,26 @@
+package com.ctrl.cbnu_archive.global.dto;
+
+import com.ctrl.cbnu_archive.global.domain.AuditLog;
+import java.time.LocalDateTime;
+
+public record AuditLogResponse(
+        Long id,
+        Long actorUserId,
+        String action,
+        String entityType,
+        Long entityId,
+        String detail,
+        LocalDateTime createdAt
+) {
+    public static AuditLogResponse fromEntity(AuditLog log) {
+        return new AuditLogResponse(
+                log.getId(),
+                log.getActorUserId(),
+                log.getAction(),
+                log.getEntityType(),
+                log.getEntityId(),
+                log.getDetail(),
+                log.getCreatedAt()
+        );
+    }
+}

--- a/backend/src/main/java/com/ctrl/cbnu_archive/global/exception/ErrorCode.java
+++ b/backend/src/main/java/com/ctrl/cbnu_archive/global/exception/ErrorCode.java
@@ -13,6 +13,7 @@ public enum ErrorCode {
     EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "A004", "만료된 토큰"),
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "U001", "사용자를 찾을 수 없습니다"),
     DUPLICATE_EMAIL(HttpStatus.CONFLICT, "U002", "이미 존재하는 이메일"),
+    USER_NOT_ACTIVE(HttpStatus.FORBIDDEN, "U003", "계정이 활성화되지 않았습니다. 관리자 승인을 기다려주세요."),
     PROJECT_NOT_FOUND(HttpStatus.NOT_FOUND, "P001", "프로젝트를 찾을 수 없습니다"),
     NOT_PROJECT_OWNER(HttpStatus.FORBIDDEN, "P002", "프로젝트 작성자만 수정/삭제할 수 있습니다"),
     FILE_UPLOAD_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "F001", "파일 업로드 실패"),

--- a/backend/src/main/java/com/ctrl/cbnu_archive/global/repository/AuditLogRepository.java
+++ b/backend/src/main/java/com/ctrl/cbnu_archive/global/repository/AuditLogRepository.java
@@ -1,0 +1,12 @@
+package com.ctrl.cbnu_archive.global.repository;
+
+import com.ctrl.cbnu_archive.global.domain.AuditLog;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface AuditLogRepository extends JpaRepository<AuditLog, Long> {
+    Page<AuditLog> findAllByOrderByCreatedAtDesc(Pageable pageable);
+}

--- a/backend/src/main/java/com/ctrl/cbnu_archive/project/controller/AdminProjectController.java
+++ b/backend/src/main/java/com/ctrl/cbnu_archive/project/controller/AdminProjectController.java
@@ -1,0 +1,86 @@
+package com.ctrl.cbnu_archive.project.controller;
+
+import com.ctrl.cbnu_archive.global.dto.AuditLogResponse;
+import com.ctrl.cbnu_archive.global.response.ApiResponse;
+import com.ctrl.cbnu_archive.global.security.jwt.CustomUserDetails;
+import com.ctrl.cbnu_archive.project.dto.AdminApproveRequest;
+import com.ctrl.cbnu_archive.project.dto.AdminRejectRequest;
+import com.ctrl.cbnu_archive.project.dto.AdminRevisionRequest;
+import com.ctrl.cbnu_archive.project.dto.AdminStatsResponse;
+import com.ctrl.cbnu_archive.project.dto.ProjectResponse;
+import com.ctrl.cbnu_archive.project.service.ProjectService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import java.util.List;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/admin/projects")
+@PreAuthorize("hasRole('ADMIN')")
+@Tag(name = "Admin Project", description = "관리자 프로젝트 관리 API")
+public class AdminProjectController {
+
+    private final ProjectService projectService;
+
+    public AdminProjectController(ProjectService projectService) {
+        this.projectService = projectService;
+    }
+
+    @Operation(summary = "승인 대기 목록 조회")
+    @GetMapping("/pending")
+    public ApiResponse<List<ProjectResponse>> getPendingProjects() {
+        return ApiResponse.success(projectService.getPendingProjects());
+    }
+
+    @Operation(summary = "프로젝트 승인")
+    @PatchMapping("/{id}/approve")
+    public ApiResponse<ProjectResponse> approveProject(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @PathVariable Long id,
+            @RequestBody AdminApproveRequest request
+    ) {
+        return ApiResponse.success(projectService.approveProject(id, request, userDetails.getId()));
+    }
+
+    @Operation(summary = "프로젝트 반려")
+    @PatchMapping("/{id}/reject")
+    public ApiResponse<ProjectResponse> rejectProject(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @PathVariable Long id,
+            @Valid @RequestBody AdminRejectRequest request
+    ) {
+        return ApiResponse.success(projectService.rejectProject(id, request, userDetails.getId()));
+    }
+
+    @Operation(summary = "수정 요청")
+    @PatchMapping("/{id}/request-revision")
+    public ApiResponse<ProjectResponse> requestRevision(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @PathVariable Long id,
+            @RequestBody AdminRevisionRequest request
+    ) {
+        return ApiResponse.success(projectService.requestRevision(id, request, userDetails.getId()));
+    }
+
+    @Operation(summary = "통계 조회")
+    @GetMapping("/stats")
+    public ApiResponse<AdminStatsResponse> getStats() {
+        return ApiResponse.success(projectService.getStats());
+    }
+
+    @Operation(summary = "감사 로그 조회")
+    @GetMapping("/audit-logs")
+    public ApiResponse<Page<AuditLogResponse>> getAuditLogs(Pageable pageable) {
+        return ApiResponse.success(projectService.getAuditLogs(pageable));
+    }
+}

--- a/backend/src/main/java/com/ctrl/cbnu_archive/project/controller/ProjectController.java
+++ b/backend/src/main/java/com/ctrl/cbnu_archive/project/controller/ProjectController.java
@@ -12,6 +12,7 @@ import com.ctrl.cbnu_archive.project.service.ProjectService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -74,6 +75,20 @@ public class ProjectController {
     ) {
         projectService.deleteProject(id, userDetails.getId(), userDetails.getAuthorities().stream().anyMatch(auth -> auth.getAuthority().equals("ROLE_ADMIN")));
         return ApiResponse.success(null);
+    }
+
+    @Operation(summary = "내 프로젝트 목록", description = "로그인한 사용자가 등록한 프로젝트 목록을 조회합니다.")
+    @GetMapping("/my")
+    public ApiResponse<List<ProjectResponse>> getMyProjects(
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        return ApiResponse.success(projectService.getMyProjects(userDetails.getId()));
+    }
+
+    @Operation(summary = "기술 스택 목록", description = "전체 기술 스택 목록을 조회합니다.")
+    @GetMapping("/tech-stacks")
+    public ApiResponse<List<String>> getTechStacks() {
+        return ApiResponse.success(projectService.getAllTechStacks());
     }
 
     @Operation(summary = "AI 추천", description = "자연어 질의를 통해 프로젝트 추천을 제공합니다.")

--- a/backend/src/main/java/com/ctrl/cbnu_archive/project/controller/SearchController.java
+++ b/backend/src/main/java/com/ctrl/cbnu_archive/project/controller/SearchController.java
@@ -1,0 +1,36 @@
+package com.ctrl.cbnu_archive.project.controller;
+
+import com.ctrl.cbnu_archive.project.dto.NaturalSearchRequest;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.Map;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.client.RestClient;
+
+@RestController
+@RequestMapping("/api/v1/search")
+@Tag(name = "Search", description = "검색 API")
+public class SearchController {
+
+    private final RestClient restClient;
+
+    public SearchController(@Value("${app.ai.base-url:http://localhost:8000}") String aiBaseUrl) {
+        this.restClient = RestClient.builder().baseUrl(aiBaseUrl).build();
+    }
+
+    @Operation(summary = "자연어 검색", description = "자연어 질의를 AI 서비스에 포워딩하여 검색 결과를 반환합니다.")
+    @PostMapping("/natural")
+    public ResponseEntity<Map> naturalSearch(@RequestBody NaturalSearchRequest request) {
+        Map response = restClient.post()
+                .uri("/search")
+                .body(request)
+                .retrieve()
+                .body(Map.class);
+        return ResponseEntity.ok(response);
+    }
+}

--- a/backend/src/main/java/com/ctrl/cbnu_archive/project/controller/TechStackController.java
+++ b/backend/src/main/java/com/ctrl/cbnu_archive/project/controller/TechStackController.java
@@ -1,0 +1,28 @@
+package com.ctrl.cbnu_archive.project.controller;
+
+import com.ctrl.cbnu_archive.global.response.ApiResponse;
+import com.ctrl.cbnu_archive.project.service.ProjectService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/tech-stacks")
+@Tag(name = "TechStack", description = "기술 스택 API")
+public class TechStackController {
+
+    private final ProjectService projectService;
+
+    public TechStackController(ProjectService projectService) {
+        this.projectService = projectService;
+    }
+
+    @Operation(summary = "기술 스택 목록 조회", description = "전체 프로젝트에서 사용된 기술 스택 목록을 반환합니다.")
+    @GetMapping
+    public ApiResponse<List<String>> getTechStacks() {
+        return ApiResponse.success(projectService.getAllTechStacks());
+    }
+}

--- a/backend/src/main/java/com/ctrl/cbnu_archive/project/domain/Project.java
+++ b/backend/src/main/java/com/ctrl/cbnu_archive/project/domain/Project.java
@@ -6,6 +6,8 @@ import jakarta.persistence.CollectionTable;
 import jakarta.persistence.Column;
 import jakarta.persistence.ElementCollection;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -50,6 +52,12 @@ public class Project extends BaseTimeEntity {
     private String domain;
     @Column(name = "is_team")
     private Boolean isTeam;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private ProjectStatus status = ProjectStatus.PENDING_APPROVAL;
+
+    private String visibility;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "author_id", nullable = false)
@@ -157,6 +165,27 @@ public class Project extends BaseTimeEntity {
 
     public void updateSummary(String summary) {
         this.summary = summary;
+    }
+
+    public ProjectStatus getStatus() {
+        return status;
+    }
+
+    public String getVisibility() {
+        return visibility;
+    }
+
+    public void approve(String visibility) {
+        this.status = ProjectStatus.APPROVED;
+        this.visibility = visibility;
+    }
+
+    public void reject() {
+        this.status = ProjectStatus.REJECTED;
+    }
+
+    public void requestRevision() {
+        this.status = ProjectStatus.REVISION_REQUESTED;
     }
 
     public void updateDetails(String title,

--- a/backend/src/main/java/com/ctrl/cbnu_archive/project/domain/ProjectStatus.java
+++ b/backend/src/main/java/com/ctrl/cbnu_archive/project/domain/ProjectStatus.java
@@ -1,0 +1,8 @@
+package com.ctrl.cbnu_archive.project.domain;
+
+public enum ProjectStatus {
+    PENDING_APPROVAL,
+    APPROVED,
+    REJECTED,
+    REVISION_REQUESTED
+}

--- a/backend/src/main/java/com/ctrl/cbnu_archive/project/dto/AdminApproveRequest.java
+++ b/backend/src/main/java/com/ctrl/cbnu_archive/project/dto/AdminApproveRequest.java
@@ -1,0 +1,4 @@
+package com.ctrl.cbnu_archive.project.dto;
+
+public record AdminApproveRequest(String visibility) {
+}

--- a/backend/src/main/java/com/ctrl/cbnu_archive/project/dto/AdminRejectRequest.java
+++ b/backend/src/main/java/com/ctrl/cbnu_archive/project/dto/AdminRejectRequest.java
@@ -1,0 +1,9 @@
+package com.ctrl.cbnu_archive.project.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record AdminRejectRequest(
+        @NotBlank(message = "반려 사유는 필수입니다.")
+        String reason
+) {
+}

--- a/backend/src/main/java/com/ctrl/cbnu_archive/project/dto/AdminRevisionRequest.java
+++ b/backend/src/main/java/com/ctrl/cbnu_archive/project/dto/AdminRevisionRequest.java
@@ -1,0 +1,6 @@
+package com.ctrl.cbnu_archive.project.dto;
+
+import java.util.List;
+
+public record AdminRevisionRequest(List<String> fields) {
+}

--- a/backend/src/main/java/com/ctrl/cbnu_archive/project/dto/AdminStatsResponse.java
+++ b/backend/src/main/java/com/ctrl/cbnu_archive/project/dto/AdminStatsResponse.java
@@ -1,0 +1,12 @@
+package com.ctrl.cbnu_archive.project.dto;
+
+import java.util.List;
+
+public record AdminStatsResponse(
+        long totalProjects,
+        long pendingCount,
+        long rejectedCount,
+        long totalDownloads,
+        List<String> topTags
+) {
+}

--- a/backend/src/main/java/com/ctrl/cbnu_archive/project/dto/NaturalSearchRequest.java
+++ b/backend/src/main/java/com/ctrl/cbnu_archive/project/dto/NaturalSearchRequest.java
@@ -1,0 +1,4 @@
+package com.ctrl.cbnu_archive.project.dto;
+
+public record NaturalSearchRequest(String query, String sessionId) {
+}

--- a/backend/src/main/java/com/ctrl/cbnu_archive/project/dto/ProjectResponse.java
+++ b/backend/src/main/java/com/ctrl/cbnu_archive/project/dto/ProjectResponse.java
@@ -1,6 +1,7 @@
 package com.ctrl.cbnu_archive.project.dto;
 
 import com.ctrl.cbnu_archive.project.domain.Project;
+import com.ctrl.cbnu_archive.project.domain.ProjectStatus;
 import com.ctrl.cbnu_archive.project.service.port.ProjectSearchResult;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -16,6 +17,8 @@ public record ProjectResponse(
         String semester,
         String difficulty,
         String domain,
+        ProjectStatus status,
+        String visibility,
         Long authorId,
         String authorName,
         LocalDateTime createdAt,
@@ -33,6 +36,8 @@ public record ProjectResponse(
                 project.getSemester(),
                 project.getDifficulty(),
                 project.getDomain(),
+                project.getStatus(),
+                project.getVisibility(),
                 project.getAuthorId(),
                 project.getAuthorName(),
                 project.getCreatedAt(),
@@ -52,6 +57,8 @@ public record ProjectResponse(
                 result.semester(),
                 result.difficulty(),
                 result.domain(),
+                null,
+                null,
                 null,
                 null,
                 null,

--- a/backend/src/main/java/com/ctrl/cbnu_archive/project/repository/ProjectRepository.java
+++ b/backend/src/main/java/com/ctrl/cbnu_archive/project/repository/ProjectRepository.java
@@ -1,12 +1,25 @@
 package com.ctrl.cbnu_archive.project.repository;
 
 import com.ctrl.cbnu_archive.project.domain.Project;
+import com.ctrl.cbnu_archive.project.domain.ProjectStatus;
+import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface ProjectRepository extends JpaRepository<Project, Long> {
     Page<Project> findByAuthorId(Long authorId, Pageable pageable);
+
+    @Query("SELECT p FROM Project p WHERE p.author.id = :authorId")
+    List<Project> findAllByAuthorId(@Param("authorId") Long authorId);
+
+    List<Project> findByStatus(ProjectStatus status);
+    long countByStatus(ProjectStatus status);
+
+    @Query(value = "SELECT DISTINCT ts.tech_stack FROM project_tech_stack ts ORDER BY ts.tech_stack", nativeQuery = true)
+    List<String> findDistinctTechStacks();
 }

--- a/backend/src/main/java/com/ctrl/cbnu_archive/project/service/ProjectService.java
+++ b/backend/src/main/java/com/ctrl/cbnu_archive/project/service/ProjectService.java
@@ -2,7 +2,15 @@ package com.ctrl.cbnu_archive.project.service;
 
 import com.ctrl.cbnu_archive.auth.domain.User;
 import com.ctrl.cbnu_archive.auth.repository.UserRepository;
+import com.ctrl.cbnu_archive.global.domain.AuditLog;
+import com.ctrl.cbnu_archive.global.dto.AuditLogResponse;
+import com.ctrl.cbnu_archive.global.repository.AuditLogRepository;
 import com.ctrl.cbnu_archive.project.domain.Project;
+import com.ctrl.cbnu_archive.project.domain.ProjectStatus;
+import com.ctrl.cbnu_archive.project.dto.AdminApproveRequest;
+import com.ctrl.cbnu_archive.project.dto.AdminRejectRequest;
+import com.ctrl.cbnu_archive.project.dto.AdminRevisionRequest;
+import com.ctrl.cbnu_archive.project.dto.AdminStatsResponse;
 import com.ctrl.cbnu_archive.project.dto.AiRecommendResponse;
 import com.ctrl.cbnu_archive.project.dto.ProjectCreateRequest;
 import com.ctrl.cbnu_archive.project.dto.ProjectResponse;
@@ -33,6 +41,7 @@ import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -48,6 +57,7 @@ public class ProjectService {
     private final AiSummaryPort aiSummaryPort;
     private final AiRecommendationPort aiRecommendationPort;
     private final ApplicationEventPublisher eventPublisher;
+    private final AuditLogRepository auditLogRepository;
 
     public ProjectService(
             ProjectRepository repository,
@@ -57,7 +67,8 @@ public class ProjectService {
             EmbeddingPort embeddingPort,
             AiSummaryPort aiSummaryPort,
             AiRecommendationPort aiRecommendationPort,
-            ApplicationEventPublisher eventPublisher
+            ApplicationEventPublisher eventPublisher,
+            AuditLogRepository auditLogRepository
     ) {
         this.repository = repository;
         this.userRepository = userRepository;
@@ -67,6 +78,7 @@ public class ProjectService {
         this.aiSummaryPort = aiSummaryPort;
         this.aiRecommendationPort = aiRecommendationPort;
         this.eventPublisher = eventPublisher;
+        this.auditLogRepository = auditLogRepository;
     }
 
     public ProjectResponse createProject(ProjectCreateRequest request, Long authorId) {
@@ -144,6 +156,60 @@ public class ProjectService {
         validateProjectOwnerOrAdmin(project, currentUser, isAdmin, "프로젝트 삭제 권한이 없습니다.");
         repository.deleteById(id);
         eventPublisher.publishEvent(new ProjectDeleteEvent(id));
+    }
+
+    public List<ProjectResponse> getMyProjects(Long userId) {
+        return repository.findAllByAuthorId(userId).stream()
+                .map(ProjectMapper::toResponse)
+                .collect(Collectors.toList());
+    }
+
+    public List<String> getAllTechStacks() {
+        return repository.findDistinctTechStacks();
+    }
+
+    public List<ProjectResponse> getPendingProjects() {
+        return repository.findByStatus(ProjectStatus.PENDING_APPROVAL).stream()
+                .map(ProjectMapper::toResponse)
+                .collect(Collectors.toList());
+    }
+
+    public ProjectResponse approveProject(Long id, AdminApproveRequest request, Long adminUserId) {
+        Project project = repository.findById(id).orElseThrow(() -> new ProjectNotFoundException(id));
+        project.approve(request.visibility());
+        Project saved = repository.save(project);
+        auditLogRepository.save(AuditLog.of(adminUserId, "APPROVE_PROJECT", "PROJECT", id, null));
+        return ProjectMapper.toResponse(saved);
+    }
+
+    public ProjectResponse rejectProject(Long id, AdminRejectRequest request, Long adminUserId) {
+        Project project = repository.findById(id).orElseThrow(() -> new ProjectNotFoundException(id));
+        project.reject();
+        Project saved = repository.save(project);
+        auditLogRepository.save(AuditLog.of(adminUserId, "REJECT_PROJECT", "PROJECT", id, request.reason()));
+        return ProjectMapper.toResponse(saved);
+    }
+
+    public ProjectResponse requestRevision(Long id, AdminRevisionRequest request, Long adminUserId) {
+        Project project = repository.findById(id).orElseThrow(() -> new ProjectNotFoundException(id));
+        project.requestRevision();
+        Project saved = repository.save(project);
+        String detail = request.fields() != null ? String.join(", ", request.fields()) : null;
+        auditLogRepository.save(AuditLog.of(adminUserId, "REQUEST_REVISION", "PROJECT", id, detail));
+        return ProjectMapper.toResponse(saved);
+    }
+
+    public AdminStatsResponse getStats() {
+        long total = repository.count();
+        long pending = repository.countByStatus(ProjectStatus.PENDING_APPROVAL);
+        long rejected = repository.countByStatus(ProjectStatus.REJECTED);
+        List<String> topTags = repository.findDistinctTechStacks().stream().limit(10).collect(Collectors.toList());
+        return new AdminStatsResponse(total, pending, rejected, 0L, topTags);
+    }
+
+    public Page<AuditLogResponse> getAuditLogs(Pageable pageable) {
+        return auditLogRepository.findAllByOrderByCreatedAtDesc(pageable)
+                .map(AuditLogResponse::fromEntity);
     }
 
     private void publishIndexEvent(Project project) {

--- a/backend/src/test/resources/application.properties
+++ b/backend/src/test/resources/application.properties
@@ -5,3 +5,7 @@ spring.datasource.driver-class-name=org.h2.Driver
 spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
 spring.jpa.hibernate.ddl-auto=create-drop
 spring.flyway.enabled=false
+app.cors.allowed-origins=http://localhost:3000,http://localhost:5173
+jwt.secret=dGVzdC1zZWNyZXQta2V5LWZvci1jYm51LWFyY2hpdmUtcHJvamVjdC1tdXN0LWJlLWxvbmctZW5vdWdoLWZvci1obWFjLXNoYS0yNTY=
+jwt.access-token-expiry=1800000
+jwt.refresh-token-expiry=1209600000


### PR DESCRIPTION
## 관련 이슈

<!--
"Closes #번호" 로 적으면 머지 시 이슈가 자동으로 닫힙니다.
이슈가 없으면 이 줄을 지워도 됩니다.
-->

Closes #25 
Closes #46 
Closes #47 
Closes #48 


---
## 개요

프론트엔드 연동에 필요한 백엔드 REST API 누락 항목을 구현했습니다.
기존 MSW(Mock Service Worker)로 동작 중인 기능들을 실제 API로 전환할 수 있도록
인증, 프로젝트 관리, 파일, 관리자 영역 전반을 보완했습니다.

---

## 변경 사항

### 1. 관리자 프로젝트 관리 API 및 자연어 검색 프록시 추가

- `ProjectStatus` enum 추가 (PENDING_APPROVAL / APPROVED / REJECTED / REVISION_REQUESTED)
- `Project` 엔티티에 `status`, `visibility` 필드 추가 — 신규 프로젝트는 기본값 `PENDING_APPROVAL`
- `AuditLog` 엔티티 추가 — 관리자 액션 이력 기록
- 관리자 전용 엔드포인트 추가 (`ADMIN` 롤 필요)
  - `GET  /api/v1/admin/projects/pending` — 승인 대기 목록 조회
  - `PATCH /api/v1/admin/projects/{id}/approve` — 프로젝트 승인
  - `PATCH /api/v1/admin/projects/{id}/reject` — 프로젝트 반려 (사유 필수)
  - `PATCH /api/v1/admin/projects/{id}/request-revision` — 수정 요청
  - `GET  /api/v1/admin/projects/stats` — 통계 조회 (전체/대기/반려 건수, 상위 태그)
  - `GET  /api/v1/admin/projects/audit-logs` — 감사 로그 조회 (페이지네이션)
- `POST /api/v1/search/natural` — AI 서비스(FastAPI :8000/search)로 자연어 검색 포워딩

### 2. 내 프로젝트 목록 및 기술 스택 조회 엔드포인트 추가

- `GET /api/v1/projects/my` — 로그인 사용자 본인이 등록한 프로젝트 목록 (인증 필수)
- `GET /api/v1/tech-stacks` — 전체 프로젝트에서 사용된 기술 스택 distinct 목록 (인증 불필요)

### 3. 회원 가입 승인 플로우 구현

- `UserStatus` enum 추가 (PENDING / ACTIVE / REJECTED)
- `User` 엔티티에 `status` 필드 추가 — 일반 가입 시 기본값 `PENDING`, ADMIN 계정은 `ACTIVE`
- 로그인 시 `ACTIVE` 상태가 아니면 403 에러 반환 (관리자 승인 대기 안내 메시지)
- 관리자 전용 엔드포인트 추가
  - `GET  /api/v1/admin/users/pending` — 승인 대기 회원 목록
  - `POST /api/v1/admin/users/{userId}/approve` — 회원 승인
  - `POST /api/v1/admin/users/{userId}/reject` — 회원 거절 (사유 선택)

### 4. 파일 다운로드 스트리밍 엔드포인트 추가

- `GET /api/v1/files/{fileId}/download` — 파일 바이트 직접 스트리밍 (인증 필수)
  - `Content-Disposition: attachment; filename*=UTF-8''<인코딩된파일명>`
  - `Content-Type: application/octet-stream`
  - 프로젝트 소유자 또는 ADMIN만 접근 가능
  - 기존 `FileStoragePort.download()` 활용 (MockFileStorageAdapter 포함)

---

## 테스트

- `./gradlew build` 통과 확인
- 테스트 환경 프로퍼티 누락 항목(`app.cors.allowed-origins`, `jwt.*`) 추가

---