### PR TITLE
[FEAT] 백엔드 API 동기화 — 연도 범위 필터, 파일 스트리밍 다운로드, 기술 스택 API, status 필드 반영

### DIFF
--- a/frontend/src/api/_adapters.ts
+++ b/frontend/src/api/_adapters.ts
@@ -14,7 +14,7 @@ export const toSummary = (p: BackendProjectResponse): ProjectSummary => ({
   teamName: p.authorName ?? '',
   techStacks: p.techStacks,
   tags: [],
-  status: 'APPROVED',   // backend does not expose status in list; default for display
+  status: p.status,
   viewCount: 0,
   downloadCount: 0,
   createdAt: p.createdAt,

--- a/frontend/src/api/files.ts
+++ b/frontend/src/api/files.ts
@@ -46,3 +46,16 @@ export const getDownloadUrl = (fileId: number) =>
   api
     .get<ApiResponse<{ downloadUrl: string }>>(`/api/v1/files/${fileId}`)
     .then((r) => r.data.data)
+
+// Stream-download a file from the backend and trigger a browser save dialog
+export const downloadFile = async (fileId: number, fileName: string): Promise<void> => {
+  const response = await api.get(`/api/v1/files/${fileId}/download`, { responseType: 'blob' })
+  const url = window.URL.createObjectURL(new Blob([response.data]))
+  const link = document.createElement('a')
+  link.href = url
+  link.setAttribute('download', fileName)
+  document.body.appendChild(link)
+  link.click()
+  link.remove()
+  window.URL.revokeObjectURL(url)
+}

--- a/frontend/src/api/projects.ts
+++ b/frontend/src/api/projects.ts
@@ -53,3 +53,6 @@ export const getRecommendations = (projectId: number) =>
   api
     .get<ApiResponse<RecommendationResult>>(`/api/v1/projects/${projectId}/recommendations`)
     .then((r) => r.data.data)
+
+export const getTechStacks = () =>
+  api.get<ApiResponse<string[]>>('/api/v1/tech-stacks').then((r) => r.data.data)

--- a/frontend/src/components/search/FilterPanel.tsx
+++ b/frontend/src/components/search/FilterPanel.tsx
@@ -1,6 +1,7 @@
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import { X } from 'lucide-react'
 import { useSearchStore } from '@/store/searchStore'
+import { getTechStacks } from '@/api/projects'
 import { Button } from '@/components/ui/Button'
 
 const DOMAIN_OPTIONS = ['웹', '앱', '인공지능', '백엔드', '클라우드', '보안', '데이터분석', '임베디드']
@@ -13,6 +14,12 @@ const YEAR_OPTIONS = Array.from({ length: CURRENT_YEAR - MIN_YEAR + 1 }, (_, i) 
 export function FilterPanel() {
   const { filters, setFilter, resetFilters } = useSearchStore()
   const [techInput, setTechInput] = useState('')
+  const [techStackOptions, setTechStackOptions] = useState<string[]>([])
+
+  // Fetch all known tech stacks from backend for datalist autocomplete
+  useEffect(() => {
+    getTechStacks().then(setTechStackOptions).catch(() => {})
+  }, [])
 
   const toggleArrayItem = <T,>(arr: T[], item: T): T[] =>
     arr.includes(item) ? arr.filter((v) => v !== item) : [...arr, item]
@@ -27,7 +34,8 @@ export function FilterPanel() {
   }
 
   const hasActiveFilter =
-    filters.years.length > 0 ||
+    filters.yearFrom !== null ||
+    filters.yearTo !== null ||
     filters.semester !== null ||
     filters.techStacks.length > 0 ||
     filters.domains.length > 0 ||
@@ -45,22 +53,32 @@ export function FilterPanel() {
         )}
       </div>
 
-      {/* 연도 — 단일 연도 선택 드롭다운 (백엔드는 year 단일 값만 지원) */}
+      {/* 수행 연도 — from / to 범위 선택 */}
       <div>
         <p className="mb-2 text-xs font-medium text-gray-500 uppercase tracking-wide">수행 연도</p>
-        <select
-          value={filters.years[0] ?? ''}
-          onChange={(e) => {
-            const v = e.target.value
-            setFilter('years', v ? [parseInt(v)] : [])
-          }}
-          className="w-full rounded-md border border-gray-200 px-2 py-1 text-xs focus:border-primary-500 focus:outline-none"
-        >
-          <option value="">전체</option>
-          {YEAR_OPTIONS.map((y) => (
-            <option key={y} value={y}>{y}년</option>
-          ))}
-        </select>
+        <div className="flex items-center gap-1">
+          <select
+            value={filters.yearFrom ?? ''}
+            onChange={(e) => setFilter('yearFrom', e.target.value ? parseInt(e.target.value) : null)}
+            className="flex-1 rounded-md border border-gray-200 px-1.5 py-1 text-xs focus:border-primary-500 focus:outline-none"
+          >
+            <option value="">시작</option>
+            {YEAR_OPTIONS.map((y) => (
+              <option key={y} value={y}>{y}</option>
+            ))}
+          </select>
+          <span className="text-xs text-gray-400">~</span>
+          <select
+            value={filters.yearTo ?? ''}
+            onChange={(e) => setFilter('yearTo', e.target.value ? parseInt(e.target.value) : null)}
+            className="flex-1 rounded-md border border-gray-200 px-1.5 py-1 text-xs focus:border-primary-500 focus:outline-none"
+          >
+            <option value="">종료</option>
+            {YEAR_OPTIONS.map((y) => (
+              <option key={y} value={y}>{y}</option>
+            ))}
+          </select>
+        </div>
       </div>
 
       {/* 학기 */}
@@ -109,6 +127,7 @@ export function FilterPanel() {
         {/* Inline search box: press Enter or comma to add a tag */}
         <input
           type="text"
+          list="tech-stack-list"
           value={techInput}
           onChange={(e) => setTechInput(e.target.value)}
           onKeyDown={(e) => {
@@ -120,6 +139,9 @@ export function FilterPanel() {
           placeholder="입력 후 Enter"
           className="mb-2 w-full rounded-md border border-gray-200 px-2.5 py-1 text-xs focus:border-primary-500 focus:outline-none"
         />
+        <datalist id="tech-stack-list">
+          {techStackOptions.map((t) => <option key={t} value={t} />)}
+        </datalist>
         {/* Active tech stack tags with remove button */}
         {filters.techStacks.length > 0 && (
           <div className="flex flex-wrap gap-1.5">

--- a/frontend/src/mocks/handlers.ts
+++ b/frontend/src/mocks/handlers.ts
@@ -27,6 +27,7 @@ const MOCK_BACKEND: BackendProjectResponse[] = [
     authorId: 1,
     authorName: '코딩마스터즈',
     createdAt: '2024-06-01T12:00:00Z',
+    status: 'APPROVED',
     updatedAt: '2024-06-01T12:00:00Z',
   },
   {
@@ -43,6 +44,7 @@ const MOCK_BACKEND: BackendProjectResponse[] = [
     authorId: 2,
     authorName: '이서연',
     createdAt: '2024-06-10T09:00:00Z',
+    status: 'APPROVED',
     updatedAt: '2024-06-10T09:00:00Z',
   },
   {
@@ -59,6 +61,7 @@ const MOCK_BACKEND: BackendProjectResponse[] = [
     authorId: 3,
     authorName: '넷이서하나',
     createdAt: '2024-01-15T10:30:00Z',
+    status: 'APPROVED',
     updatedAt: '2024-01-15T10:30:00Z',
   },
   {
@@ -75,6 +78,7 @@ const MOCK_BACKEND: BackendProjectResponse[] = [
     authorId: 4,
     authorName: '쿼리마스터',
     createdAt: '2024-12-10T08:00:00Z',
+    status: 'APPROVED',
     updatedAt: '2024-12-10T08:00:00Z',
   },
   {
@@ -91,6 +95,7 @@ const MOCK_BACKEND: BackendProjectResponse[] = [
     authorId: 5,
     authorName: '비전팀',
     createdAt: '2023-06-20T14:00:00Z',
+    status: 'APPROVED',
     updatedAt: '2023-06-20T14:00:00Z',
   },
   {
@@ -107,6 +112,7 @@ const MOCK_BACKEND: BackendProjectResponse[] = [
     authorId: 6,
     authorName: '마켓팀',
     createdAt: '2025-06-05T10:00:00Z',
+    status: 'APPROVED',
     updatedAt: '2025-06-05T10:00:00Z',
   },
   {
@@ -123,6 +129,7 @@ const MOCK_BACKEND: BackendProjectResponse[] = [
     authorId: 7,
     authorName: '박지훈',
     createdAt: '2024-12-18T09:30:00Z',
+    status: 'APPROVED',
     updatedAt: '2024-12-18T09:30:00Z',
   },
   {
@@ -139,6 +146,7 @@ const MOCK_BACKEND: BackendProjectResponse[] = [
     authorId: 8,
     authorName: 'AutoReview',
     createdAt: '2025-05-30T11:00:00Z',
+    status: 'APPROVED',
     updatedAt: '2025-05-30T11:00:00Z',
   },
   {
@@ -155,6 +163,7 @@ const MOCK_BACKEND: BackendProjectResponse[] = [
     authorId: 9,
     authorName: '동아리팀',
     createdAt: '2023-12-05T13:00:00Z',
+    status: 'APPROVED',
     updatedAt: '2023-12-05T13:00:00Z',
   },
 ]

--- a/frontend/src/pages/ProjectDetail.tsx
+++ b/frontend/src/pages/ProjectDetail.tsx
@@ -5,7 +5,7 @@ import remarkGfm from 'remark-gfm'
 import remarkBreaks from 'remark-breaks'
 import { Download, FileText, Pencil, Trash2, ChevronLeft } from 'lucide-react'
 import { getProjectDetail, deleteProject, getRecommendations } from '@/api/projects'
-import { getDownloadUrl } from '@/api/files'
+import { downloadFile } from '@/api/files'
 import { useAuthStore } from '@/store/authStore'
 import type { ProjectDetail as ProjectDetailType } from '@/types/project'
 import type { RecommendationItem } from '@/types/project'
@@ -237,15 +237,9 @@ function FileDownloadRow({ file }: { file: import('@/types/file').ProjectFile })
   const handleDownload = async () => {
     setLoading(true)
     try {
-      const { downloadUrl } = await getDownloadUrl(file.id)
-      // Mock storage URLs are fake and cannot be resolved externally
-      if (downloadUrl.includes('mock-storage')) {
-        alert('파일 다운로드 기능은 현재 서버 업데이트 후 이용 가능합니다.\n빠른 시일 내에 지원될 예정입니다.')
-        return
-      }
-      window.open(downloadUrl, '_blank', 'noopener,noreferrer')
+      await downloadFile(file.id, file.originalName)
     } catch {
-      alert('파일 URL을 가져오지 못했습니다. 잠시 후 다시 시도해주세요.')
+      alert('파일 다운로드에 실패했습니다. 잠시 후 다시 시도해주세요.')
     } finally {
       setLoading(false)
     }

--- a/frontend/src/pages/ProjectList.tsx
+++ b/frontend/src/pages/ProjectList.tsx
@@ -31,9 +31,9 @@ export default function ProjectList() {
     try {
       const result = await searchKeyword({
         keyword: kw || undefined,
-        // Backend supports only a single year filter; send undefined when a range is selected
-        // so results are not filtered by year (all years shown)
-        year: filters.years.length === 1 ? filters.years[0] : undefined,
+        // Pass yearFrom / yearTo directly — backend now supports range filter
+        yearFrom: filters.yearFrom ?? undefined,
+        yearTo: filters.yearTo ?? undefined,
         semester: filters.semester === 1 ? 'FIRST' : filters.semester === 2 ? 'SECOND' : undefined,
         domain: filters.domains[0],
         techStacks: filters.techStacks.length > 0 ? filters.techStacks : undefined,

--- a/frontend/src/pages/ProjectUpload.tsx
+++ b/frontend/src/pages/ProjectUpload.tsx
@@ -1,10 +1,11 @@
-import { useState, useRef } from 'react'
+import { useState, useRef, useEffect } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { Upload, X, Plus, FileText, AlertCircle } from 'lucide-react'
 import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
 import remarkBreaks from 'remark-breaks'
 import { api } from '@/api/axiosInstance'
+import { getTechStacks } from '@/api/projects'
 import type { ApiResponse } from '@/types/api'
 import type { BackendProjectResponse } from '@/types/project'
 
@@ -57,6 +58,12 @@ export default function ProjectUpload() {
 
   const [attachedFiles, setAttachedFiles] = useState<AttachedFile[]>([])
   const [techInput, setTechInput] = useState('')
+  const [techStackOptions, setTechStackOptions] = useState<string[]>([])
+
+  // Fetch known tech stacks for datalist autocomplete
+  useEffect(() => {
+    getTechStacks().then(setTechStackOptions).catch(() => {})
+  }, [])
   const [isSubmitting, setIsSubmitting] = useState(false)
   const [submitError, setSubmitError] = useState<string | null>(null)
   const [dragOver, setDragOver] = useState(false)
@@ -260,9 +267,13 @@ export default function ProjectUpload() {
               value={techInput}
               onChange={(e) => setTechInput(e.target.value)}
               onKeyDown={handleTechKeyDown}
+              list="tech-stack-list-upload"
               placeholder="입력 후 Enter"
               className="min-w-24 flex-1 border-none bg-transparent text-sm outline-none"
             />
+            <datalist id="tech-stack-list-upload">
+              {techStackOptions.map((t) => <option key={t} value={t} />)}
+            </datalist>
           </div>
           <p className="mt-1 text-xs text-gray-400">Enter 또는 쉼표(,)로 태그 추가</p>
         </div>

--- a/frontend/src/store/searchStore.ts
+++ b/frontend/src/store/searchStore.ts
@@ -2,7 +2,8 @@ import { create } from 'zustand'
 import type { SortOption } from '@/types/project'
 
 interface SearchFilters {
-  years: number[]
+  yearFrom: number | null
+  yearTo: number | null
   semester: 1 | 2 | null
   subjects: string[]
   techStacks: string[]
@@ -25,7 +26,8 @@ interface SearchState {
 }
 
 const DEFAULT_FILTERS: SearchFilters = {
-  years: [],
+  yearFrom: null,
+  yearTo: null,
   semester: null,
   subjects: [],
   techStacks: [],

--- a/frontend/src/types/project.ts
+++ b/frontend/src/types/project.ts
@@ -32,6 +32,7 @@ export interface BackendProjectResponse {
   domain: string
   authorId: number
   authorName: string
+  status: ProjectStatus
   createdAt: string
   updatedAt: string
 }
@@ -117,7 +118,8 @@ export interface RecommendationResult {
 export interface KeywordSearchParams {
   keyword?: string
   techStacks?: string[]
-  year?: number
+  yearFrom?: number
+  yearTo?: number
   semester?: string
   difficulty?: string
   domain?: string


### PR DESCRIPTION
## 관련 이슈

Closes #49

---

## 변경 내용과 그 이유

백엔드 PR #52, #53 병합으로 추가된 API 변경 사항을 프론트엔드에 반영합니다.

**1. 연도 범위 필터 (`yearFrom` / `yearTo`)**
`year: number | null` → `yearFrom / yearTo` 로 변경 (`searchStore.ts`, `types/project.ts`, `ProjectList.tsx`)
`FilterPanel.tsx`에 "연도 from~to" 셀렉트 UI 추가

**2. 파일 스트리밍 다운로드**
`ProjectDetail.tsx`: `getDownloadUrl()` 대신 `downloadFile()` Fetch 스트리밍으로 교체 (`api/files.ts` 추가)

**3. 기술 스택 자동완성**
`GET /api/v1/tech-stacks` 연동 (`api/projects.ts` 추가)
`FilterPanel.tsx`, `ProjectUpload.tsx`에 `<datalist>` 자동완성 추가

**4. status 필드 어댑터 수정**
`_adapters.ts`: `status: 'APPROVED'` 하드코딩 → `p.status` 실제 값 반영
`mocks/handlers.ts`: 모든 목 데이터에 `status: 'APPROVED'` 추가

---

## 메모 (선택)

- `seed_projects.py`는 `.gitignore` 대상이라 이 PR에 포함되지 않습니다. 로컬에서만 수정되었습니다.
- 시드 스크립트를 정상 실행하려면 백엔드에 기본 ADMIN 계정 자동 생성 로직(DataInitializer)이 필요합니다. 별도 이슈 등록 예정.