### PR TITLE
[FEAT(backend)] AI 서비스 연동 실 어댑터 구현

### DIFF
--- a/backend/src/main/java/com/ctrl/cbnu_archive/project/service/adapter/ai/AiServiceRecommendationAdapter.java
+++ b/backend/src/main/java/com/ctrl/cbnu_archive/project/service/adapter/ai/AiServiceRecommendationAdapter.java
@@ -1,0 +1,49 @@
+package com.ctrl.cbnu_archive.project.service.adapter.ai;
+
+import com.ctrl.cbnu_archive.project.service.port.AiRecommendationPort;
+import com.ctrl.cbnu_archive.project.service.port.AiRecommendationResult;
+import com.ctrl.cbnu_archive.project.service.port.ProjectContext;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.client.RestClientException;
+
+@Component
+@ConditionalOnProperty(prefix = "app.adapter", name = "ai-recommendation", havingValue = "ai")
+public class AiServiceRecommendationAdapter implements AiRecommendationPort {
+
+    private static final Logger log = LoggerFactory.getLogger(AiServiceRecommendationAdapter.class);
+    private final RestClient restClient;
+
+    public AiServiceRecommendationAdapter(@Value("${app.ai.base-url:http://localhost:8000}") String aiBaseUrl) {
+        this.restClient = RestClient.builder().baseUrl(aiBaseUrl).build();
+    }
+
+    @Override
+    public AiRecommendationResult recommend(String userQuery, List<ProjectContext> retrievedDocs) {
+        List<Long> projectIds = retrievedDocs == null ? Collections.emptyList()
+                : retrievedDocs.stream().map(ProjectContext::projectId).collect(Collectors.toList());
+        try {
+            Map<String, Object> request = Map.of("query", userQuery, "top_k", 5);
+            Map<?, ?> response = restClient.post()
+                    .uri("/search")
+                    .body(request)
+                    .retrieve()
+                    .body(Map.class);
+            if (response != null) {
+                String answer = response.get("answer") instanceof String s ? s : "";
+                return new AiRecommendationResult(answer, projectIds, "벡터 유사도 기반 검색 결과");
+            }
+        } catch (RestClientException e) {
+            log.warn("[AI] recommend 실패 - AI 서비스 연결 오류: {}", e.getMessage());
+        }
+        return new AiRecommendationResult("AI 검색 서비스를 일시적으로 이용할 수 없습니다.", projectIds, "");
+    }
+}

--- a/backend/src/main/java/com/ctrl/cbnu_archive/project/service/adapter/ai/AiServiceSummaryAdapter.java
+++ b/backend/src/main/java/com/ctrl/cbnu_archive/project/service/adapter/ai/AiServiceSummaryAdapter.java
@@ -1,0 +1,90 @@
+package com.ctrl.cbnu_archive.project.service.adapter.ai;
+
+import com.ctrl.cbnu_archive.project.service.port.AiSummaryPort;
+import com.ctrl.cbnu_archive.project.service.port.ExtractedMetadata;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.client.RestClientException;
+
+@Component
+@ConditionalOnProperty(prefix = "app.adapter", name = "ai-summary", havingValue = "ai")
+public class AiServiceSummaryAdapter implements AiSummaryPort {
+
+    private static final Logger log = LoggerFactory.getLogger(AiServiceSummaryAdapter.class);
+    private final RestClient restClient;
+
+    public AiServiceSummaryAdapter(@Value("${app.ai.base-url:http://localhost:8000}") String aiBaseUrl) {
+        this.restClient = RestClient.builder().baseUrl(aiBaseUrl).build();
+    }
+
+    @Override
+    public String summarize(String readme, String description) {
+        try {
+            Map<String, Object> request = buildProjectInput(description, readme);
+            Map<?, ?> response = restClient.post()
+                    .uri("/metadata/analyze")
+                    .body(request)
+                    .retrieve()
+                    .body(Map.class);
+            if (response != null && response.get("passage_text") instanceof String passageText) {
+                return passageText;
+            }
+        } catch (RestClientException e) {
+            log.warn("[AI] summarize 실패 - AI 서비스 연결 오류: {}", e.getMessage());
+        }
+        return description != null ? description : "";
+    }
+
+    @Override
+    public ExtractedMetadata extractMetadata(String text) {
+        try {
+            Map<String, Object> request = buildProjectInput(text, "");
+            Map<?, ?> response = restClient.post()
+                    .uri("/metadata/analyze")
+                    .body(request)
+                    .retrieve()
+                    .body(Map.class);
+            if (response != null) {
+                List<String> techStacks = toStringList(response.get("tech_stack"));
+                String domain = response.get("topic") instanceof String s ? s : null;
+                String difficulty = response.get("difficulty") instanceof String s ? s : null;
+                return new ExtractedMetadata(techStacks, domain, difficulty);
+            }
+        } catch (RestClientException e) {
+            log.warn("[AI] extractMetadata 실패 - AI 서비스 연결 오류: {}", e.getMessage());
+        }
+        return new ExtractedMetadata(Collections.emptyList(), null, null);
+    }
+
+    private Map<String, Object> buildProjectInput(String description, String readme) {
+        Map<String, Object> map = new HashMap<>();
+        map.put("project_id", 0);
+        map.put("title", "");
+        map.put("short_summary", "");
+        map.put("description", description != null ? description : "");
+        map.put("readme", readme != null ? readme : "");
+        map.put("report_text", "");
+        map.put("file_names", Collections.emptyList());
+        map.put("folder_paths", Collections.emptyList());
+        map.put("config_texts", Collections.emptyMap());
+        map.put("course_name", "");
+        map.put("semester", "");
+        return map;
+    }
+
+    @SuppressWarnings("unchecked")
+    private List<String> toStringList(Object value) {
+        if (value instanceof List<?> list) {
+            return (List<String>) list;
+        }
+        return Collections.emptyList();
+    }
+}

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -8,6 +8,16 @@ app:
     allowed-origins:
       - http://localhost:3000
       - http://localhost:5173
+  ai:
+    base-url: http://localhost:8000
+  # AI 서비스 연동 어댑터 설정
+  # 각 항목을 "ai"로 변경하면 실제 AI 서비스와 연결됩니다 (mock: 기본값, ai: 실제 연동)
+  adapter:
+    ai-summary: mock
+    ai-recommendation: mock
+    embedding: mock
+    vector: mock
+    search: mock
 
 spring:
   servlet:


### PR DESCRIPTION
  ## 작업 내용

  백엔드와 AI 서비스 간 연결이 누락되어 있던 부분을 구현하였습니다.
  기존에는 모든 AI 관련 포트(`AiSummaryPort`, `AiRecommendationPort`)가
  Mock 어댑터만 존재하여 실제 AI 서비스와 통신하지 않았습니다.

  ### 추가된 파일
  - `AiServiceSummaryAdapter` — `POST /metadata/analyze` 호출
    - 프로젝트 등록/수정 시 AI가 요약 및 메타데이터(기술스택, 도메인, 난이도) 자동 추출
  - `AiServiceRecommendationAdapter` — `POST /search` 호출
    - `/api/v1/projects/recommend` 요청 시 AI RAG 파이프라인 기반 추천 답변 반환

  ### 변경된 파일
  - `application.yml` — `app.ai.base-url` 명시, 어댑터 전환 설정 추가

  ## 어댑터 전환 방법

  `application.yml`에서 값 변경으로 Mock ↔ AI 서비스 전환 가능합니다.

  ```yaml
  app:
    adapter:
      ai-summary: ai          # mock → ai로 변경 시 실제 AI 서비스 연동
      ai-recommendation: ai   # mock → ai로 변경 시 실제 AI 서비스 연동

  ▎ AI 서비스가 실행 중이지 않거나 연결 오류 발생 시 fallback 응답을 반환하므로
  ▎ 서비스 중단 없이 동작합니다.

  테스트

  - ./gradlew test 전체 통과 확인
  - 기존 Mock 어댑터와 bean 충돌 없음 확인

  ---