### PR TITLE
[FEAT(backend)] 운영 환경 실 어댑터 구현 및 Spring Profile 분리

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -24,6 +24,9 @@ repositories {
 }
 
 dependencies {
+	implementation platform('software.amazon.awssdk:bom:2.27.0')
+	implementation 'software.amazon.awssdk:s3'
+	implementation 'software.amazon.awssdk:s3-transfer-manager'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'

--- a/backend/report_task1_profile_flyway.txt
+++ b/backend/report_task1_profile_flyway.txt
@@ -1,0 +1,91 @@
+작업 제목: Spring Profile 분리 (dev/prod) + Flyway V1 마이그레이션 스크립트 작성
+작업일: 2026-05-28
+담당: 백엔드
+
+
+── 배경 및 문제점 ──────────────────────────────────────────────
+
+기존 application.yml 하나에 H2 인메모리 DB, ddl-auto: create-drop, 모든 어댑터 mock,
+Flyway disabled 설정이 한꺼번에 들어 있었다.
+이 상태에서는 개발/운영 환경 전환 시 파일을 직접 수정해야 했고,
+실수로 운영 DB에 create-drop이 적용될 위험이 있었다.
+또한 Flyway 마이그레이션 폴더(db/migration)가 .gitkeep만 있는 빈 상태였기 때문에
+PostgreSQL을 실제로 연결해도 테이블이 자동으로 생성되지 않는 문제가 있었다.
+
+
+── 작업 내용 ───────────────────────────────────────────────────
+
+1) application.yml (공통 설정)
+   - JWT secret, access/refresh 만료 시간
+   - CORS 허용 오리진
+   - AI 서비스 base-url
+   - 멀티파트 업로드 크기 제한
+   - 프로파일 기본값: dev (환경변수 SPRING_PROFILES_ACTIVE 로 오버라이드 가능)
+   - 민감값(JWT secret, AI URL)은 환경변수 우선 참조로 변경
+     예: ${JWT_SECRET:기존_기본값}
+
+2) application-dev.yml (개발 환경)
+   - DB: H2 인메모리 (jdbc:h2:mem:testdb)
+   - ddl-auto: create-drop  (앱 재시작 시 스키마 재생성)
+   - show-sql: true, format_sql: true
+   - Flyway: disabled
+   - H2 콘솔: /h2-console 활성화
+   - 모든 어댑터(ai-summary, ai-recommendation, embedding, vector, search, storage): mock
+
+3) application-prod.yml (운영 환경)
+   - DB: PostgreSQL (환경변수로 URL/계정 주입)
+     DB_URL      기본값: jdbc:postgresql://localhost:5432/cbnu_archive
+     DB_USERNAME 기본값: postgres
+     DB_PASSWORD 기본값: (빈 값, 반드시 설정 필요)
+   - ddl-auto: validate  (Flyway가 스키마 관리, JPA는 검증만)
+   - show-sql: false
+   - Flyway: enabled, classpath:db/migration
+   - AI 어댑터: ai-summary=ai, ai-recommendation=ai  (실 AI 서비스 연동)
+   - embedding, vector, search, storage: 아직 실 어댑터 미구현으로 mock 유지
+
+4) db/migration/V1__init.sql (Flyway 초기 스키마)
+   생성 테이블 목록:
+   - users            : 회원 (이메일, 비밀번호, 이름, 학번, 역할, 상태, 생성/수정일)
+   - projects         : 프로젝트 (제목, 요약, 설명, README, 년도, 학기, 난이도, 도메인, 팀여부, 상태, 공개범위, 작성자FK)
+   - project_tech_stack : 프로젝트-기술스택 N:1 (project_id FK + CASCADE DELETE)
+   - project_files    : 첨부파일 (파일명, 타입, 크기, 스토리지키, 업로드일, 프로젝트FK + CASCADE DELETE)
+   - audit_logs       : 관리자 감사 로그 (행위자, 액션, 엔티티타입/ID, 상세, 생성일)
+
+   인덱스:
+   - users(email), users(status)
+   - projects(author_id), projects(status), projects(project_year), projects(domain)
+   - project_tech_stack(project_id)
+   - project_files(project_id)
+   - audit_logs(actor_user_id), audit_logs(created_at DESC), audit_logs(entity_type, entity_id)
+
+   초기 데이터:
+   - ADMIN 계정 1건 (admin@cbnu.ac.kr / admin1234 BCrypt 해시)
+   - 운영 배포 전 비밀번호 변경 필요 (주석으로 명시)
+
+
+── 변경된 파일 목록 ─────────────────────────────────────────────
+
+수정:
+  backend/src/main/resources/application.yml
+
+신규:
+  backend/src/main/resources/application-dev.yml
+  backend/src/main/resources/application-prod.yml
+  backend/src/main/resources/db/migration/V1__init.sql
+
+
+── 환경변수 정리 (운영 배포 시 필수) ────────────────────────────
+
+SPRING_PROFILES_ACTIVE=prod
+JWT_SECRET=<충분히 긴 Base64 인코딩 비밀 키>
+AI_BASE_URL=http://<AI서비스 호스트>:8000
+DB_URL=jdbc:postgresql://<호스트>:5432/cbnu_archive
+DB_USERNAME=<DB 계정>
+DB_PASSWORD=<DB 비밀번호>
+
+
+── 검증 ────────────────────────────────────────────────────────
+
+./gradlew compileJava 통과 (컴파일 오류 없음)
+H2 인메모리 모드(dev profile)는 기존과 동일하게 동작
+운영(prod) profile은 PostgreSQL + Flyway 활성화, AI 어댑터 실 연동 상태로 기동

--- a/backend/report_task2_embedding_adapter.txt
+++ b/backend/report_task2_embedding_adapter.txt
@@ -1,0 +1,87 @@
+작업 제목: EmbeddingPort 실 AI 서비스 어댑터 구현
+작업일: 2026-05-28
+담당: 백엔드
+
+
+── 배경 및 문제점 ──────────────────────────────────────────────
+
+EmbeddingPort 인터페이스는 정의되어 있었으나, 실제 구현체가 없어
+MockEmbeddingAdapter(텍스트 해시 기반 가짜 벡터)만 사용 가능한 상태였다.
+
+EmbeddingPort는 두 곳에서 사용된다.
+  1) ProjectIndexEventListener - 프로젝트 등록/수정 시 텍스트를 벡터로 변환해 VectorStore에 저장
+  2) ProjectService.recommendByQuery() - 사용자 자연어 쿼리를 벡터로 변환해 유사 프로젝트 검색
+
+가짜 벡터로는 벡터 유사도 검색이 의미 없으므로 실 AI 서비스 연동 어댑터가 필요했다.
+
+
+── 작업 내용 ───────────────────────────────────────────────────
+
+신규 파일: AiServiceEmbeddingAdapter.java
+경로: project/service/adapter/ai/AiServiceEmbeddingAdapter.java
+활성 조건: app.adapter.embedding=ai
+
+구현 메서드:
+  embed(String text) -> float[]
+    - POST {ai-base-url}/embed  body: {"text": "..."}
+    - 응답: {"embedding": [0.12, 0.34, ...]}
+    - 파싱 실패 또는 연결 오류 시 빈 배열(float[0]) 반환 후 warn 로그
+
+  embedBatch(List<String> texts) -> List<float[]>
+    - POST {ai-base-url}/embed  body: {"texts": ["...", "..."]}
+    - 응답: {"embeddings": [[...], [...]]}
+    - 파싱 실패 또는 연결 오류 시 빈 리스트 반환 후 warn 로그
+
+설계 결정 사항:
+  - 응답에서 차원(dimension)을 하드코딩하지 않고 파싱 시 실제 배열 크기를 그대로 사용
+    -> AI 서비스 모델 교체 시 어댑터 수정 불필요
+  - RestClientException 발생 시 예외를 상위로 전파하지 않고 빈 결과 + warn 로그 처리
+    -> 인덱싱 실패가 사용자 요청 전체를 막지 않도록 방어적 설계
+  - AI 서비스 base-url은 기존 ${app.ai.base-url} 프로퍼티 공유
+    -> AiServiceSummaryAdapter, AiServiceRecommendationAdapter와 동일한 설정 재사용
+
+가정한 AI 서비스 API 스펙:
+  단건:  POST /embed   {"text": "입력 텍스트"}
+         응답          {"embedding": [float, float, ...]}
+  배치:  POST /embed   {"texts": ["텍스트1", "텍스트2"]}
+         응답          {"embeddings": [[float, ...], [float, ...]]}
+
+  실제 AI 서비스 스펙이 다를 경우 parseEmbedding() / parseBatchEmbeddings() 내부만
+  수정하면 되므로 변경 범위가 최소화된다.
+
+
+── application-prod.yml 변경 ────────────────────────────────────
+
+변경 전: embedding: mock
+변경 후: embedding: ai
+
+prod 프로파일 기준 현재 어댑터 활성 상태:
+  ai-summary:       ai   (실 AI 서비스 /metadata/analyze)
+  ai-recommendation:ai   (실 AI 서비스 /search)
+  embedding:        ai   (실 AI 서비스 /embed)  ← 이번 작업으로 전환
+  vector:           mock (실 VectorDB 어댑터 미구현)
+  search:           mock (실 검색엔진 어댑터 미구현)
+  storage:          mock (실 파일스토리지 어댑터 미구현)
+
+
+── 변경된 파일 목록 ─────────────────────────────────────────────
+
+신규:
+  backend/src/main/java/.../adapter/ai/AiServiceEmbeddingAdapter.java
+
+수정:
+  backend/src/main/resources/application-prod.yml
+    (embedding: mock -> embedding: ai)
+
+
+── 검증 ────────────────────────────────────────────────────────
+
+./gradlew compileJava 통과 (컴파일 오류 없음)
+dev 프로파일: MockEmbeddingAdapter 그대로 사용 (기존 동작 유지)
+prod 프로파일: AiServiceEmbeddingAdapter 활성화, AI 서비스 호출
+
+
+── 향후 과제 ────────────────────────────────────────────────────
+
+AI 서비스의 실제 /embed 엔드포인트 스펙 확인 후 필요 시 파싱 로직 보정
+VectorSearchPort 실 어댑터 구현 (현재 mock - pgvector 또는 외부 벡터 DB 연동 필요)

--- a/backend/report_task3_s3_storage_adapter.txt
+++ b/backend/report_task3_s3_storage_adapter.txt
@@ -1,0 +1,110 @@
+작업 제목: FileStoragePort S3 실 어댑터 구현
+작업일: 2026-05-28
+담당: 백엔드
+
+
+── 배경 및 문제점 ──────────────────────────────────────────────
+
+FileStoragePort 인터페이스는 정의되어 있었으나, 실제 구현체가 없어
+MockFileStorageAdapter(JVM 메모리 내 Map에 파일 저장)만 존재했다.
+메모리 기반 구현이므로 서버 재시작 시 모든 파일이 삭제되고,
+다중 인스턴스 환경에서는 인스턴스 간 파일 공유가 불가능하다.
+운영 환경에서는 영속적인 외부 오브젝트 스토리지 연동이 필수다.
+
+
+── 작업 내용 ───────────────────────────────────────────────────
+
+1) build.gradle 의존성 추가
+   - AWS SDK v2 BOM (software.amazon.awssdk:bom:2.27.0)
+   - software.amazon.awssdk:s3           - S3 동기 클라이언트
+   - software.amazon.awssdk:s3-transfer-manager - 대용량 멀티파트 전송 (향후 활용)
+
+2) 신규 파일: S3FileStorageAdapter.java
+   경로: file/service/adapter/s3/S3FileStorageAdapter.java
+   활성 조건: app.adapter.storage=s3
+
+   구현 메서드:
+     upload(path, InputStream, size, contentType) -> String(저장 키)
+       - PutObjectRequest로 S3에 업로드
+       - contentType null 시 application/octet-stream 기본 적용
+
+     download(storedKey) -> InputStream
+       - GetObjectRequest로 S3에서 스트림 반환
+       - 호출자가 스트림 닫기 책임 (FileService에서 처리)
+
+     delete(storedKey)
+       - DeleteObjectRequest로 S3 오브젝트 삭제
+
+     generatePresignedUrl(storedKey, Duration) -> String(URL)
+       - S3Presigner로 임시 서명 URL 생성 (FileService에서 15분 TTL 적용)
+       - 프론트엔드가 이 URL로 직접 S3에서 파일 다운로드 가능
+
+   인증 방식:
+     AWS 기본 자격증명 체인(DefaultCredentialsProvider) 자동 적용
+       1순위: 환경변수 AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY
+       2순위: ~/.aws/credentials 파일
+       3순위: EC2/ECS IAM 인스턴스 프로파일
+     -> 코드에 자격증명 하드코딩 없음, 배포 환경에 맞게 자동 선택
+
+3) application-prod.yml 변경
+   storage 어댑터: mock -> s3
+   S3 설정 추가:
+     app.storage.s3.bucket : ${S3_BUCKET:cbnu-archive-files}
+     app.storage.s3.region : ${S3_REGION:ap-northeast-2}  (기본: 서울 리전)
+
+
+── 변경된 파일 목록 ─────────────────────────────────────────────
+
+수정:
+  backend/build.gradle
+    (AWS SDK v2 BOM + s3 + s3-transfer-manager 의존성 추가)
+  backend/src/main/resources/application-prod.yml
+    (storage: mock -> s3, S3 버킷/리전 설정 추가)
+
+신규:
+  backend/src/main/java/.../file/service/adapter/s3/S3FileStorageAdapter.java
+
+
+── prod 프로파일 어댑터 최종 상태 ──────────────────────────────
+
+  ai-summary:        ai   (실 AI 서비스 /metadata/analyze)
+  ai-recommendation: ai   (실 AI 서비스 /search)
+  embedding:         ai   (실 AI 서비스 /embed)
+  storage:           s3   (AWS S3)  ← 이번 작업으로 전환
+  vector:            mock (실 VectorDB 어댑터 미구현)
+  search:            mock (실 검색엔진 어댑터 미구현)
+
+
+── 환경변수 (운영 배포 시 필수 추가) ────────────────────────────
+
+S3_BUCKET=<버킷 이름>
+S3_REGION=ap-northeast-2   (서울 리전 기본값)
+AWS_ACCESS_KEY_ID=<액세스 키>          (또는 IAM 인스턴스 프로파일 사용)
+AWS_SECRET_ACCESS_KEY=<시크릿 키>
+
+
+── 사전 준비 사항 (인프라) ──────────────────────────────────────
+
+S3 버킷 생성
+  - 버킷 이름: S3_BUCKET 환경변수 값과 동일하게 설정
+  - 리전: ap-northeast-2 (서울) 권장
+  - 퍼블릭 액세스 차단: 활성화 (Presigned URL로만 접근)
+
+IAM 정책 (최소 권한):
+  s3:PutObject
+  s3:GetObject
+  s3:DeleteObject
+  s3:GetObjectAcl
+  Resource: arn:aws:s3:::<버킷이름>/projects/*
+
+CORS 설정 (브라우저에서 Presigned URL로 직접 업로드할 경우):
+  AllowedOrigins: 프론트엔드 도메인
+  AllowedMethods: GET, PUT
+  AllowedHeaders: *
+
+
+── 검증 ────────────────────────────────────────────────────────
+
+./gradlew compileJava 통과 (컴파일 오류 없음)
+dev 프로파일: MockFileStorageAdapter 그대로 사용 (기존 동작 유지)
+prod 프로파일: S3FileStorageAdapter 활성화, S3 버킷에 실제 저장

--- a/backend/report_task4_postgres_search_adapter.txt
+++ b/backend/report_task4_postgres_search_adapter.txt
@@ -1,0 +1,121 @@
+작업 제목: ProjectSearchPort PostgreSQL 실 어댑터 구현 (JPA Specification 기반)
+작업일: 2026-05-28
+담당: 백엔드
+
+
+── 배경 및 문제점 ──────────────────────────────────────────────
+
+ProjectSearchPort는 프로젝트 키워드/필터 검색을 담당하는 인터페이스다.
+기존 MockProjectSearchAdapter는 JVM 메모리 내 ConcurrentHashMap에
+인덱스된 데이터를 저장하고 검색했다.
+
+문제점:
+  - 서버 재시작 시 인덱스가 초기화되어 검색 불가
+  - 다중 인스턴스 배포 시 인스턴스 간 인덱스 불일치
+  - Elasticsearch 등 별도 검색 엔진 없이 실 운영 불가
+
+해결 방향:
+  Elasticsearch 같은 별도 인프라 없이, 이미 사용 중인 PostgreSQL의
+  JPA Specification(Criteria API)을 활용해 검색 어댑터를 구현했다.
+  추가 서비스 의존성 없이 운영 가능하다.
+
+
+── 작업 내용 ───────────────────────────────────────────────────
+
+1) ProjectRepository에 JpaSpecificationExecutor 추가
+   - JpaRepository<Project, Long>에 JpaSpecificationExecutor<Project> 추가 상속
+   - 이를 통해 findAll(Specification, Pageable) 메서드 사용 가능
+
+2) 신규 파일: ProjectSpecification.java
+   경로: project/repository/ProjectSpecification.java
+   역할: 각 필터 조건을 JPA Specification 객체로 정의
+
+   포함된 스펙:
+     approved()              - 상태가 APPROVED인 프로젝트만 검색
+     hasKeyword(keyword)     - title / summary / description / domain 에 LIKE 검색
+     hasAllTechStacks(list)  - 지정된 기술 스택을 모두 보유한 프로젝트 (EXISTS 서브쿼리 AND)
+     yearFrom(year)          - project_year >= yearFrom
+     yearTo(year)            - project_year <= yearTo
+     hasSemester(semester)   - semester 일치 (FIRST/1, SECOND/2 정규화 포함)
+     hasDifficulty(str)      - difficulty 일치
+     hasDomain(str)          - domain 일치
+     isTeam(bool)            - isTeam 일치
+
+   기술 스택 필터 구현 방식:
+     "지정한 기술 스택을 모두 포함"하는 프로젝트를 찾기 위해
+     각 기술 스택마다 EXISTS 서브쿼리를 생성하고 AND로 결합.
+     예) React, TypeScript 두 개 지정 시:
+       WHERE EXISTS (SELECT 1 FROM project_tech_stack WHERE project_id=p.id AND LOWER(tech_stack)='react')
+         AND EXISTS (SELECT 1 FROM project_tech_stack WHERE project_id=p.id AND LOWER(tech_stack)='typescript')
+
+3) 신규 파일: PostgresProjectSearchAdapter.java
+   경로: project/service/adapter/postgres/PostgresProjectSearchAdapter.java
+   활성 조건: app.adapter.search=postgres
+
+   구현 메서드:
+     index(ProjectIndexDocument) - no-op
+       데이터는 JPA를 통해 projects 테이블에 이미 저장되므로 별도 인덱싱 불필요
+
+     delete(Long projectId) - no-op
+       삭제는 JPA(ProjectRepository.deleteById)가 처리하므로 중복 작업 없음
+
+     search(SearchQuery) -> List<ProjectSearchResult>
+       buildSpec()으로 Specification 조합 후
+       projectRepository.findAll(spec, PageRequest) 호출
+       결과를 ProjectSearchResult 레코드로 변환하여 반환
+       score 필드: 1.0f 고정 (관련도 점수 미지원, 향후 확장 가능)
+
+4) application-prod.yml 변경
+   search: mock -> search: postgres
+
+
+── 설계 결정 사항 ────────────────────────────────────────────────
+
+Elasticsearch 대신 PostgreSQL JPA Specification을 선택한 이유:
+  - 현재 프로젝트 데이터 규모(대학 과제 수백~수천 건)에서 PostgreSQL로 충분
+  - 추가 인프라(Elasticsearch 클러스터) 없이 기존 DB 하나로 운영 가능
+  - 향후 데이터가 수십만 건 이상으로 증가하면 Elasticsearch 어댑터로 교체 가능
+    (포트 인터페이스가 동일하므로 어댑터만 교체하면 됨)
+
+index()/delete() no-op 처리:
+  Mock 어댑터는 별도 인덱스 저장소를 유지했지만,
+  PostgreSQL 어댑터는 JPA가 이미 DB를 최신 상태로 유지하므로
+  별도 인덱싱이 불필요하다. ProjectIndexEventListener에서 호출되는
+  searchPort.index()는 no-op으로 처리되어 불필요한 DB 연산을 방지한다.
+
+
+── 변경된 파일 목록 ─────────────────────────────────────────────
+
+수정:
+  backend/src/main/java/.../project/repository/ProjectRepository.java
+    (JpaSpecificationExecutor<Project> 추가)
+  backend/src/main/resources/application-prod.yml
+    (search: mock -> search: postgres)
+
+신규:
+  backend/src/main/java/.../project/repository/ProjectSpecification.java
+  backend/src/main/java/.../project/service/adapter/postgres/PostgresProjectSearchAdapter.java
+
+
+── prod 프로파일 어댑터 최종 상태 ──────────────────────────────
+
+  ai-summary:        ai       (실 AI 서비스 /metadata/analyze)
+  ai-recommendation: ai       (실 AI 서비스 /search)
+  embedding:         ai       (실 AI 서비스 /embed)
+  storage:           s3       (AWS S3)
+  search:            postgres (JPA Specification + PostgreSQL)  ← 이번 작업
+  vector:            mock     (실 VectorDB 어댑터 미구현)
+
+
+── 검증 ────────────────────────────────────────────────────────
+
+./gradlew compileJava 통과 (컴파일 오류 없음)
+dev 프로파일: MockProjectSearchAdapter 그대로 사용 (기존 동작 유지)
+prod 프로파일: PostgresProjectSearchAdapter 활성화, JPA + PostgreSQL 검색
+
+
+── 향후 과제 ────────────────────────────────────────────────────
+
+VectorSearchPort 실 어댑터 구현
+  - pgvector PostgreSQL 확장 사용 시: V2 Flyway 마이그레이션으로 vector 컬럼 추가 필요
+  - 외부 벡터 DB(Pinecone 등) 사용 시: 별도 어댑터 구현 필요

--- a/backend/report_task5_pgvector_adapter.txt
+++ b/backend/report_task5_pgvector_adapter.txt
@@ -1,0 +1,135 @@
+작업 제목: VectorSearchPort pgvector 실 어댑터 구현
+작업일: 2026-05-28
+담당: 백엔드
+
+
+── 배경 및 문제점 ──────────────────────────────────────────────
+
+VectorSearchPort 인터페이스는 텍스트 임베딩 벡터를 저장/검색하는 역할을 한다.
+기존 MockVectorSearchAdapter는 JVM 메모리 내 ConcurrentHashMap에 벡터를 저장해
+코사인 유사도를 Java 코드로 직접 계산했다.
+
+문제점:
+  - 서버 재시작 시 모든 벡터 데이터 소실
+  - 다중 인스턴스 배포 시 인스턴스 간 벡터 인덱스 불일치
+  - Java 기반 선형 탐색(O(n)) 방식으로 대용량 데이터에서 성능 저하
+
+해결 방향:
+  PostgreSQL의 pgvector 확장을 사용해 벡터를 DB에 영속 저장하고
+  ANN(Approximate Nearest Neighbor) 인덱스(HNSW)로 빠른 유사도 검색을 제공한다.
+  추가 벡터 DB(Pinecone, Weaviate 등) 없이 기존 PostgreSQL에 통합 가능하다.
+
+
+── 작업 내용 ───────────────────────────────────────────────────
+
+1) Flyway 마이그레이션 추가: V2__add_vector_store.sql
+   경로: db/migration/V2__add_vector_store.sql
+
+   실행 내용:
+     CREATE EXTENSION IF NOT EXISTS vector
+       -> pgvector 확장 활성화 (PostgreSQL 슈퍼유저 권한 필요)
+
+     CREATE TABLE project_vectors
+       컬럼:
+         project_id BIGINT PRIMARY KEY  (projects 테이블 FK, CASCADE DELETE)
+         embedding  vector(384)         (384차원 임베딩 벡터)
+         metadata   JSONB               (title, difficulty, domain 등 부가 정보)
+
+     CREATE INDEX idx_project_vectors_hnsw
+       -> HNSW 인덱스, vector_cosine_ops 사용 (pgvector 0.5.0 이상 필요)
+       -> 코사인 유사도 기반 ANN 검색에 최적화
+
+   차원(384) 기준:
+     sentence-transformers/all-MiniLM-L6-v2 모델의 출력 차원과 동일
+     AI 서비스 모델 변경 시 새 Flyway 마이그레이션으로 차원 재정의 필요
+
+2) 신규 파일: PgVectorSearchAdapter.java
+   경로: project/service/adapter/pgvector/PgVectorSearchAdapter.java
+   활성 조건: app.adapter.vector=pgvector
+
+   구현 메서드:
+     upsert(projectId, float[], metadata)
+       - INSERT ... ON CONFLICT (project_id) DO UPDATE 로 upsert 처리
+       - float[] -> "[0.1,0.2,...]" 문자열 변환 후 CAST(? AS vector) 로 DB 저장
+       - metadata(Map) -> Jackson으로 JSON 직렬화 후 CAST(? AS jsonb) 저장
+       - 빈 임베딩(length=0) 수신 시 warn 로그 후 건너뜀
+
+     searchSimilar(float[] queryEmbedding, int topK)
+       - 코사인 유사도: 1 - (embedding <=> query_vector)
+         (pgvector의 <=> 연산자는 코사인 거리, 1에서 빼면 유사도)
+       - ORDER BY embedding <=> query_vector LIMIT topK
+       - 결과를 VectorMatch(projectId, score, metadata=Map.of()) 로 반환
+       - 빈 쿼리 벡터 수신 시 빈 리스트 반환
+
+     delete(projectId)
+       - DELETE FROM project_vectors WHERE project_id = ?
+
+   구현 특징:
+     - 별도 pgvector Java 라이브러리 없이 JdbcTemplate + 네이티브 SQL만 사용
+       -> 의존성 최소화, JDBC 레벨에서 CAST(? AS vector) 문법으로 직접 처리
+     - ObjectMapper(Jackson)는 Spring Boot 자동 구성으로 주입
+       -> 별도 Bean 정의 불필요
+
+3) application-prod.yml 변경
+   vector: mock -> vector: pgvector
+
+
+── SQL 핵심 쿼리 ─────────────────────────────────────────────────
+
+UPSERT:
+  INSERT INTO project_vectors (project_id, embedding, metadata)
+  VALUES (?, CAST(? AS vector), CAST(? AS jsonb))
+  ON CONFLICT (project_id) DO UPDATE
+  SET embedding = EXCLUDED.embedding, metadata = EXCLUDED.metadata
+
+유사도 검색:
+  SELECT project_id,
+         1 - (embedding <=> CAST(? AS vector)) AS score
+  FROM project_vectors
+  ORDER BY embedding <=> CAST(? AS vector)
+  LIMIT ?
+
+
+── 변경된 파일 목록 ─────────────────────────────────────────────
+
+신규:
+  backend/src/main/resources/db/migration/V2__add_vector_store.sql
+  backend/src/main/java/.../adapter/pgvector/PgVectorSearchAdapter.java
+
+수정:
+  backend/src/main/resources/application-prod.yml
+    (vector: mock -> vector: pgvector)
+
+
+── prod 프로파일 어댑터 최종 상태 (전체 완료) ────────────────────
+
+  ai-summary:        ai        (실 AI 서비스 /metadata/analyze)
+  ai-recommendation: ai        (실 AI 서비스 /search)
+  embedding:         ai        (실 AI 서비스 /embed)
+  storage:           s3        (AWS S3)
+  search:            postgres  (JPA Specification + PostgreSQL ILIKE)
+  vector:            pgvector  (PostgreSQL pgvector 확장)  ← 이번 작업
+
+  모든 어댑터가 실 구현으로 전환 완료.
+  dev 프로파일은 전체 mock 유지 (기존 동작 그대로).
+
+
+── 인프라 사전 요구사항 (운영 배포 전 체크리스트) ─────────────────
+
+  PostgreSQL 서버에 pgvector 확장 설치
+    Ubuntu/Debian: apt-get install postgresql-16-pgvector
+    Docker 이미지: pgvector/pgvector:pg16 사용 권장
+
+  Flyway 마이그레이션 실행 시 DB 계정에 CREATE EXTENSION 권한 필요
+    GRANT CREATE ON DATABASE cbnu_archive TO <db_user>;
+    또는 슈퍼유저 계정으로 'CREATE EXTENSION vector;' 선실행 후 Flyway 마이그레이션 진행
+
+  pgvector 버전 0.5.0 이상 권장 (HNSW 인덱스 지원)
+    버전 확인: SELECT extversion FROM pg_extension WHERE extname = 'vector';
+
+
+── 검증 ────────────────────────────────────────────────────────
+
+./gradlew compileJava 통과 (컴파일 오류 없음)
+dev 프로파일: MockVectorSearchAdapter 그대로 사용 (기존 동작 유지)
+prod 프로파일: PgVectorSearchAdapter 활성화, PostgreSQL project_vectors 테이블 사용

--- a/backend/src/main/java/com/ctrl/cbnu_archive/file/service/adapter/s3/S3FileStorageAdapter.java
+++ b/backend/src/main/java/com/ctrl/cbnu_archive/file/service/adapter/s3/S3FileStorageAdapter.java
@@ -1,0 +1,83 @@
+package com.ctrl.cbnu_archive.file.service.adapter.s3;
+
+import com.ctrl.cbnu_archive.file.service.port.FileStoragePort;
+import java.io.InputStream;
+import java.time.Duration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.services.s3.presigner.model.GetObjectPresignRequest;
+
+@Component
+@ConditionalOnProperty(prefix = "app.adapter", name = "storage", havingValue = "s3")
+public class S3FileStorageAdapter implements FileStoragePort {
+
+    private static final Logger log = LoggerFactory.getLogger(S3FileStorageAdapter.class);
+
+    private final S3Client s3Client;
+    private final S3Presigner presigner;
+    private final String bucket;
+
+    public S3FileStorageAdapter(
+            @Value("${app.storage.s3.bucket}") String bucket,
+            @Value("${app.storage.s3.region:ap-northeast-2}") String region) {
+        this.bucket = bucket;
+        Region awsRegion = Region.of(region);
+        this.s3Client = S3Client.builder().region(awsRegion).build();
+        this.presigner = S3Presigner.builder().region(awsRegion).build();
+        log.info("[S3] FileStorageAdapter 초기화: bucket={}, region={}", bucket, region);
+    }
+
+    @Override
+    public String upload(String path, InputStream is, long size, String contentType) {
+        PutObjectRequest request = PutObjectRequest.builder()
+                .bucket(bucket)
+                .key(path)
+                .contentType(contentType != null ? contentType : "application/octet-stream")
+                .contentLength(size)
+                .build();
+        s3Client.putObject(request, RequestBody.fromInputStream(is, size));
+        log.info("[S3] upload 완료: key={}, size={}", path, size);
+        return path;
+    }
+
+    @Override
+    public InputStream download(String storedKey) {
+        GetObjectRequest request = GetObjectRequest.builder()
+                .bucket(bucket)
+                .key(storedKey)
+                .build();
+        log.info("[S3] download 요청: key={}", storedKey);
+        return s3Client.getObject(request);
+    }
+
+    @Override
+    public void delete(String storedKey) {
+        DeleteObjectRequest request = DeleteObjectRequest.builder()
+                .bucket(bucket)
+                .key(storedKey)
+                .build();
+        s3Client.deleteObject(request);
+        log.info("[S3] delete 완료: key={}", storedKey);
+    }
+
+    @Override
+    public String generatePresignedUrl(String storedKey, Duration ttl) {
+        GetObjectPresignRequest request = GetObjectPresignRequest.builder()
+                .signatureDuration(ttl)
+                .getObjectRequest(b -> b.bucket(bucket).key(storedKey))
+                .build();
+        String url = presigner.presignGetObject(request).url().toString();
+        log.debug("[S3] presigned URL 생성: key={}, ttl={}s", storedKey, ttl.toSeconds());
+        return url;
+    }
+}

--- a/backend/src/main/java/com/ctrl/cbnu_archive/project/repository/ProjectRepository.java
+++ b/backend/src/main/java/com/ctrl/cbnu_archive/project/repository/ProjectRepository.java
@@ -6,12 +6,13 @@ import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface ProjectRepository extends JpaRepository<Project, Long> {
+public interface ProjectRepository extends JpaRepository<Project, Long>, JpaSpecificationExecutor<Project> {
     Page<Project> findByAuthorId(Long authorId, Pageable pageable);
 
     @Query("SELECT p FROM Project p WHERE p.author.id = :authorId")

--- a/backend/src/main/java/com/ctrl/cbnu_archive/project/repository/ProjectSpecification.java
+++ b/backend/src/main/java/com/ctrl/cbnu_archive/project/repository/ProjectSpecification.java
@@ -1,0 +1,105 @@
+package com.ctrl.cbnu_archive.project.repository;
+
+import com.ctrl.cbnu_archive.project.domain.Project;
+import com.ctrl.cbnu_archive.project.domain.ProjectStatus;
+import jakarta.persistence.criteria.Join;
+import jakarta.persistence.criteria.Predicate;
+import jakarta.persistence.criteria.Subquery;
+import java.util.ArrayList;
+import java.util.List;
+import org.springframework.data.jpa.domain.Specification;
+
+public final class ProjectSpecification {
+
+    private ProjectSpecification() {
+    }
+
+    public static Specification<Project> approved() {
+        return (root, query, cb) ->
+                cb.equal(root.get("status"), ProjectStatus.APPROVED);
+    }
+
+    public static Specification<Project> hasKeyword(String keyword) {
+        return (root, query, cb) -> {
+            if (keyword == null || keyword.isBlank()) {
+                return cb.conjunction();
+            }
+            String pattern = "%" + keyword.toLowerCase() + "%";
+            return cb.or(
+                    cb.like(cb.lower(root.get("title")), pattern),
+                    cb.like(cb.lower(root.get("summary")), pattern),
+                    cb.like(cb.lower(root.get("description")), pattern),
+                    cb.like(cb.lower(root.get("domain")), pattern)
+            );
+        };
+    }
+
+    public static Specification<Project> hasAllTechStacks(List<String> techStacks) {
+        return (root, query, cb) -> {
+            if (techStacks == null || techStacks.isEmpty()) {
+                return cb.conjunction();
+            }
+            // 지정된 기술 스택을 모두 포함하는 프로젝트 필터 (AND 조건)
+            List<Predicate> predicates = new ArrayList<>();
+            for (String techStack : techStacks) {
+                Subquery<Long> sub = query.subquery(Long.class);
+                var subRoot = sub.correlate(root);
+                Join<Project, String> join = subRoot.join("techStacks");
+                sub.select(cb.literal(1L))
+                        .where(cb.equal(cb.lower(join), techStack.toLowerCase()));
+                predicates.add(cb.exists(sub));
+            }
+            return cb.and(predicates.toArray(new Predicate[0]));
+        };
+    }
+
+    public static Specification<Project> yearFrom(Integer yearFrom) {
+        return (root, query, cb) -> {
+            if (yearFrom == null) return cb.conjunction();
+            return cb.greaterThanOrEqualTo(root.get("year"), yearFrom);
+        };
+    }
+
+    public static Specification<Project> yearTo(Integer yearTo) {
+        return (root, query, cb) -> {
+            if (yearTo == null) return cb.conjunction();
+            return cb.lessThanOrEqualTo(root.get("year"), yearTo);
+        };
+    }
+
+    public static Specification<Project> hasSemester(String semester) {
+        return (root, query, cb) -> {
+            if (semester == null || semester.isBlank()) return cb.conjunction();
+            return cb.equal(root.get("semester"), normalizeSemester(semester));
+        };
+    }
+
+    public static Specification<Project> hasDifficulty(String difficulty) {
+        return (root, query, cb) -> {
+            if (difficulty == null || difficulty.isBlank()) return cb.conjunction();
+            return cb.equal(root.get("difficulty"), difficulty);
+        };
+    }
+
+    public static Specification<Project> hasDomain(String domain) {
+        return (root, query, cb) -> {
+            if (domain == null || domain.isBlank()) return cb.conjunction();
+            return cb.equal(root.get("domain"), domain);
+        };
+    }
+
+    public static Specification<Project> isTeam(Boolean isTeam) {
+        return (root, query, cb) -> {
+            if (isTeam == null) return cb.conjunction();
+            return cb.equal(root.get("isTeam"), isTeam);
+        };
+    }
+
+    private static String normalizeSemester(String s) {
+        return switch (s.toUpperCase()) {
+            case "1", "FIRST" -> "FIRST";
+            case "2", "SECOND" -> "SECOND";
+            default -> s.toUpperCase();
+        };
+    }
+}

--- a/backend/src/main/java/com/ctrl/cbnu_archive/project/service/adapter/ai/AiServiceEmbeddingAdapter.java
+++ b/backend/src/main/java/com/ctrl/cbnu_archive/project/service/adapter/ai/AiServiceEmbeddingAdapter.java
@@ -1,0 +1,107 @@
+package com.ctrl.cbnu_archive.project.service.adapter.ai;
+
+import com.ctrl.cbnu_archive.project.service.port.EmbeddingPort;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.client.RestClientException;
+
+@Component
+@ConditionalOnProperty(prefix = "app.adapter", name = "embedding", havingValue = "ai")
+public class AiServiceEmbeddingAdapter implements EmbeddingPort {
+
+    private static final Logger log = LoggerFactory.getLogger(AiServiceEmbeddingAdapter.class);
+
+    private final RestClient restClient;
+
+    public AiServiceEmbeddingAdapter(
+            @Value("${app.ai.base-url:http://localhost:8000}") String aiBaseUrl) {
+        this.restClient = RestClient.builder().baseUrl(aiBaseUrl).build();
+    }
+
+    @Override
+    public float[] embed(String text) {
+        Objects.requireNonNull(text, "text must not be null");
+        try {
+            Map<?, ?> response = restClient.post()
+                    .uri("/embed")
+                    .body(Map.of("text", text))
+                    .retrieve()
+                    .body(Map.class);
+            return parseEmbedding(response, "embedding");
+        } catch (RestClientException e) {
+            log.warn("[AI] embed 실패 - AI 서비스 연결 오류: {}", e.getMessage());
+            return new float[0];
+        }
+    }
+
+    @Override
+    public List<float[]> embedBatch(List<String> texts) {
+        Objects.requireNonNull(texts, "texts must not be null");
+        if (texts.isEmpty()) {
+            return Collections.emptyList();
+        }
+        try {
+            Map<?, ?> response = restClient.post()
+                    .uri("/embed")
+                    .body(Map.of("texts", texts))
+                    .retrieve()
+                    .body(Map.class);
+            return parseBatchEmbeddings(response);
+        } catch (RestClientException e) {
+            log.warn("[AI] embedBatch 실패 - AI 서비스 연결 오류: {}", e.getMessage());
+            return Collections.emptyList();
+        }
+    }
+
+    private float[] parseEmbedding(Map<?, ?> response, String key) {
+        if (response == null) {
+            return new float[0];
+        }
+        Object raw = response.get(key);
+        if (!(raw instanceof List<?> list)) {
+            log.warn("[AI] 응답에 '{}' 필드가 없거나 형식이 잘못되었습니다. response={}", key, response);
+            return new float[0];
+        }
+        return toFloatArray(list);
+    }
+
+    private List<float[]> parseBatchEmbeddings(Map<?, ?> response) {
+        if (response == null) {
+            return Collections.emptyList();
+        }
+        Object raw = response.get("embeddings");
+        if (!(raw instanceof List<?> outer)) {
+            log.warn("[AI] 배치 응답에 'embeddings' 필드가 없거나 형식이 잘못되었습니다.");
+            return Collections.emptyList();
+        }
+        List<float[]> result = new ArrayList<>(outer.size());
+        for (Object item : outer) {
+            if (item instanceof List<?> inner) {
+                result.add(toFloatArray(inner));
+            } else {
+                result.add(new float[0]);
+            }
+        }
+        return result;
+    }
+
+    private float[] toFloatArray(List<?> list) {
+        float[] arr = new float[list.size()];
+        for (int i = 0; i < list.size(); i++) {
+            Object val = list.get(i);
+            if (val instanceof Number n) {
+                arr[i] = n.floatValue();
+            }
+        }
+        return arr;
+    }
+}

--- a/backend/src/main/java/com/ctrl/cbnu_archive/project/service/adapter/pgvector/PgVectorSearchAdapter.java
+++ b/backend/src/main/java/com/ctrl/cbnu_archive/project/service/adapter/pgvector/PgVectorSearchAdapter.java
@@ -1,0 +1,117 @@
+package com.ctrl.cbnu_archive.project.service.adapter.pgvector;
+
+import com.ctrl.cbnu_archive.project.service.port.VectorMatch;
+import com.ctrl.cbnu_archive.project.service.port.VectorSearchPort;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+@ConditionalOnProperty(prefix = "app.adapter", name = "vector", havingValue = "pgvector")
+public class PgVectorSearchAdapter implements VectorSearchPort {
+
+    private static final Logger log = LoggerFactory.getLogger(PgVectorSearchAdapter.class);
+
+    private static final String UPSERT_SQL =
+            "INSERT INTO project_vectors (project_id, embedding, metadata) " +
+            "VALUES (?, CAST(? AS vector), CAST(? AS jsonb)) " +
+            "ON CONFLICT (project_id) DO UPDATE " +
+            "SET embedding = EXCLUDED.embedding, metadata = EXCLUDED.metadata";
+
+    private static final String SEARCH_SQL =
+            "SELECT project_id, " +
+            "       1 - (embedding <=> CAST(? AS vector)) AS score " +
+            "FROM project_vectors " +
+            "ORDER BY embedding <=> CAST(? AS vector) " +
+            "LIMIT ?";
+
+    private static final String DELETE_SQL =
+            "DELETE FROM project_vectors WHERE project_id = ?";
+
+    private final JdbcTemplate jdbcTemplate;
+    private final ObjectMapper objectMapper;
+
+    public PgVectorSearchAdapter(JdbcTemplate jdbcTemplate, ObjectMapper objectMapper) {
+        this.jdbcTemplate = jdbcTemplate;
+        this.objectMapper = objectMapper;
+    }
+
+    @Override
+    public void upsert(Long projectId, float[] embedding, Map<String, Object> metadata) {
+        Objects.requireNonNull(projectId, "projectId must not be null");
+        Objects.requireNonNull(embedding, "embedding must not be null");
+
+        if (embedding.length == 0) {
+            log.warn("[PGVECTOR] upsert 건너뜀: 빈 임베딩 벡터 projectId={}", projectId);
+            return;
+        }
+
+        String vectorStr = toVectorString(embedding);
+        String metadataJson = toJson(metadata);
+
+        jdbcTemplate.update(UPSERT_SQL, projectId, vectorStr, metadataJson);
+        log.info("[PGVECTOR] upsert 완료: projectId={}, dim={}", projectId, embedding.length);
+    }
+
+    @Override
+    public List<VectorMatch> searchSimilar(float[] queryEmbedding, int topK) {
+        Objects.requireNonNull(queryEmbedding, "queryEmbedding must not be null");
+
+        if (queryEmbedding.length == 0) {
+            log.warn("[PGVECTOR] searchSimilar 건너뜀: 빈 쿼리 벡터");
+            return Collections.emptyList();
+        }
+
+        String vectorStr = toVectorString(queryEmbedding);
+
+        List<VectorMatch> results = jdbcTemplate.query(
+                SEARCH_SQL,
+                (rs, rowNum) -> new VectorMatch(
+                        rs.getLong("project_id"),
+                        rs.getFloat("score"),
+                        Map.of()
+                ),
+                vectorStr, vectorStr, topK
+        );
+
+        log.info("[PGVECTOR] searchSimilar 완료: topK={}, 결과={}건", topK, results.size());
+        return results;
+    }
+
+    @Override
+    public void delete(Long projectId) {
+        Objects.requireNonNull(projectId, "projectId must not be null");
+        int deleted = jdbcTemplate.update(DELETE_SQL, projectId);
+        log.info("[PGVECTOR] delete 완료: projectId={}, deleted={}", projectId, deleted);
+    }
+
+    private String toVectorString(float[] embedding) {
+        StringBuilder sb = new StringBuilder("[");
+        for (int i = 0; i < embedding.length; i++) {
+            if (i > 0) sb.append(",");
+            sb.append(embedding[i]);
+        }
+        sb.append("]");
+        return sb.toString();
+    }
+
+    private String toJson(Map<String, Object> metadata) {
+        if (metadata == null || metadata.isEmpty()) {
+            return "{}";
+        }
+        try {
+            return objectMapper.writeValueAsString(metadata);
+        } catch (JsonProcessingException e) {
+            log.warn("[PGVECTOR] metadata JSON 직렬화 실패: {}", e.getMessage());
+            return "{}";
+        }
+    }
+}

--- a/backend/src/main/java/com/ctrl/cbnu_archive/project/service/adapter/postgres/PostgresProjectSearchAdapter.java
+++ b/backend/src/main/java/com/ctrl/cbnu_archive/project/service/adapter/postgres/PostgresProjectSearchAdapter.java
@@ -1,0 +1,76 @@
+package com.ctrl.cbnu_archive.project.service.adapter.postgres;
+
+import com.ctrl.cbnu_archive.project.domain.Project;
+import com.ctrl.cbnu_archive.project.repository.ProjectRepository;
+import com.ctrl.cbnu_archive.project.repository.ProjectSpecification;
+import com.ctrl.cbnu_archive.project.service.port.ProjectIndexDocument;
+import com.ctrl.cbnu_archive.project.service.port.ProjectSearchPort;
+import com.ctrl.cbnu_archive.project.service.port.ProjectSearchResult;
+import com.ctrl.cbnu_archive.project.service.port.SearchQuery;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.jpa.domain.Specification;
+import org.springframework.stereotype.Component;
+
+@Component
+@ConditionalOnProperty(prefix = "app.adapter", name = "search", havingValue = "postgres")
+public class PostgresProjectSearchAdapter implements ProjectSearchPort {
+
+    private static final Logger log = LoggerFactory.getLogger(PostgresProjectSearchAdapter.class);
+
+    private final ProjectRepository projectRepository;
+
+    public PostgresProjectSearchAdapter(ProjectRepository projectRepository) {
+        this.projectRepository = projectRepository;
+    }
+
+    @Override
+    public void index(ProjectIndexDocument doc) {
+        // 데이터는 JPA를 통해 projects 테이블에 이미 저장되므로 별도 인덱싱 불필요
+        log.debug("[POSTGRES] index 호출 (no-op): projectId={}", doc.projectId());
+    }
+
+    @Override
+    public void delete(Long projectId) {
+        // 삭제는 JPA가 처리하므로 별도 작업 불필요
+        log.debug("[POSTGRES] delete 호출 (no-op): projectId={}", projectId);
+    }
+
+    @Override
+    public List<ProjectSearchResult> search(SearchQuery query) {
+        Specification<Project> spec = buildSpec(query);
+        PageRequest pageable = PageRequest.of(query.page(), query.size());
+
+        return projectRepository.findAll(spec, pageable).stream()
+                .map(project -> new ProjectSearchResult(
+                        project.getId(),
+                        project.getTitle(),
+                        project.getSummary(),
+                        project.getTechStacks(),
+                        project.getYear(),
+                        project.getSemester(),
+                        project.getDifficulty(),
+                        project.getDomain(),
+                        project.getIsTeam(),
+                        1.0f
+                ))
+                .collect(Collectors.toList());
+    }
+
+    private Specification<Project> buildSpec(SearchQuery query) {
+        Specification<Project> spec = ProjectSpecification.approved();
+        spec = spec.and(ProjectSpecification.hasKeyword(query.keyword()));
+        spec = spec.and(ProjectSpecification.hasAllTechStacks(query.techStacks()));
+        spec = spec.and(ProjectSpecification.yearFrom(query.yearFrom()));
+        spec = spec.and(ProjectSpecification.yearTo(query.yearTo()));
+        spec = spec.and(ProjectSpecification.hasSemester(query.semester()));
+        spec = spec.and(ProjectSpecification.hasDifficulty(query.difficulty()));
+        spec = spec.and(ProjectSpecification.hasDomain(query.domain()));
+        spec = spec.and(ProjectSpecification.isTeam(query.isTeam()));
+        return spec;
+    }
+}

--- a/backend/src/main/resources/application-dev.yml
+++ b/backend/src/main/resources/application-dev.yml
@@ -1,0 +1,28 @@
+spring:
+  datasource:
+    url: jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+    driver-class-name: org.h2.Driver
+    username: sa
+    password:
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    show-sql: true
+    properties:
+      hibernate:
+        format_sql: true
+  flyway:
+    enabled: false
+  h2:
+    console:
+      enabled: true
+      path: /h2-console
+
+app:
+  adapter:
+    ai-summary: mock
+    ai-recommendation: mock
+    embedding: mock
+    vector: mock
+    search: mock
+    storage: mock

--- a/backend/src/main/resources/application-prod.yml
+++ b/backend/src/main/resources/application-prod.yml
@@ -1,0 +1,30 @@
+spring:
+  datasource:
+    url: ${DB_URL:jdbc:postgresql://localhost:5432/cbnu_archive}
+    driver-class-name: org.postgresql.Driver
+    username: ${DB_USERNAME:postgres}
+    password: ${DB_PASSWORD:}
+  jpa:
+    hibernate:
+      ddl-auto: validate
+    show-sql: false
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.PostgreSQLDialect
+  flyway:
+    enabled: true
+    locations: classpath:db/migration
+    baseline-on-migrate: true
+
+app:
+  adapter:
+    ai-summary: ai
+    ai-recommendation: ai
+    embedding: ai
+    vector: pgvector
+    search: postgres
+    storage: s3
+  storage:
+    s3:
+      bucket: ${S3_BUCKET:cbnu-archive-files}
+      region: ${S3_REGION:ap-northeast-2}

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -1,5 +1,5 @@
 jwt:
-  secret: dGVzdC1zZWNyZXQta2V5LWZvci1jYm51LWFyY2hpdmUtcHJvamVjdC1tdXN0LWJlLWxvbmctZW5vdWdoLWZvci1obWFjLXNoYS0yNTY=
+  secret: ${JWT_SECRET:dGVzdC1zZWNyZXQta2V5LWZvci1jYm51LWFyY2hpdmUtcHJvamVjdC1tdXN0LWJlLWxvbmctZW5vdWdoLWZvci1obWFjLXNoYS0yNTY=}
   access-token-expiry: 1800000
   refresh-token-expiry: 1209600000
 
@@ -9,29 +9,12 @@ app:
       - http://localhost:3000
       - http://localhost:5173
   ai:
-    base-url: http://localhost:8000
-  # AI 서비스 연동 어댑터 설정
-  # 각 항목을 "ai"로 변경하면 실제 AI 서비스와 연결됩니다 (mock: 기본값, ai: 실제 연동)
-  adapter:
-    ai-summary: mock
-    ai-recommendation: mock
-    embedding: mock
-    vector: mock
-    search: mock
+    base-url: ${AI_BASE_URL:http://localhost:8000}
 
 spring:
   servlet:
     multipart:
       max-file-size: 50MB
       max-request-size: 100MB
-  flyway:
-    enabled: false
-  jpa:
-    hibernate:
-      ddl-auto: create-drop
-    show-sql: true
-  datasource:
-    url: jdbc:h2:mem:testdb
-    driver-class-name: org.h2.Driver
-    username: sa
-    password:
+  profiles:
+    active: ${SPRING_PROFILES_ACTIVE:dev}

--- a/backend/src/main/resources/db/migration/V1__init.sql
+++ b/backend/src/main/resources/db/migration/V1__init.sql
@@ -1,0 +1,94 @@
+-- ============================================================
+-- V1__init.sql  :  cbnu-archive 초기 스키마
+-- ============================================================
+
+-- ── users ──────────────────────────────────────────────────
+CREATE TABLE users (
+    id             BIGSERIAL    PRIMARY KEY,
+    email          VARCHAR(255) NOT NULL UNIQUE,
+    password       VARCHAR(255) NOT NULL,
+    name           VARCHAR(100) NOT NULL,
+    student_number VARCHAR(50)  UNIQUE,
+    role           VARCHAR(20)  NOT NULL DEFAULT 'USER',
+    status         VARCHAR(20)  NOT NULL DEFAULT 'PENDING',
+    created_at     TIMESTAMP    NOT NULL DEFAULT NOW(),
+    updated_at     TIMESTAMP    NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_users_email  ON users (email);
+CREATE INDEX idx_users_status ON users (status);
+
+-- ── projects ───────────────────────────────────────────────
+CREATE TABLE projects (
+    id           BIGSERIAL    PRIMARY KEY,
+    title        VARCHAR(255) NOT NULL,
+    summary      TEXT,
+    description  TEXT,
+    readme       TEXT,
+    project_year INTEGER,
+    semester     VARCHAR(20),
+    difficulty   VARCHAR(20),
+    domain       VARCHAR(100),
+    is_team      BOOLEAN,
+    status       VARCHAR(30)  NOT NULL DEFAULT 'PENDING_APPROVAL',
+    visibility   VARCHAR(30),
+    author_id    BIGINT       NOT NULL REFERENCES users (id),
+    created_at   TIMESTAMP    NOT NULL DEFAULT NOW(),
+    updated_at   TIMESTAMP    NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_projects_author_id    ON projects (author_id);
+CREATE INDEX idx_projects_status       ON projects (status);
+CREATE INDEX idx_projects_project_year ON projects (project_year);
+CREATE INDEX idx_projects_domain       ON projects (domain);
+
+-- ── project_tech_stack ─────────────────────────────────────
+CREATE TABLE project_tech_stack (
+    project_id BIGINT       NOT NULL REFERENCES projects (id) ON DELETE CASCADE,
+    tech_stack VARCHAR(100) NOT NULL
+);
+
+CREATE INDEX idx_pts_project_id ON project_tech_stack (project_id);
+
+-- ── project_files ──────────────────────────────────────────
+CREATE TABLE project_files (
+    id          BIGSERIAL    PRIMARY KEY,
+    file_name   VARCHAR(255) NOT NULL,
+    file_type   VARCHAR(20)  NOT NULL,
+    size        BIGINT       NOT NULL,
+    storage_key VARCHAR(500) NOT NULL UNIQUE,
+    uploaded_at TIMESTAMP    NOT NULL DEFAULT NOW(),
+    project_id  BIGINT       NOT NULL REFERENCES projects (id) ON DELETE CASCADE
+);
+
+CREATE INDEX idx_project_files_project_id ON project_files (project_id);
+
+-- ── audit_logs ─────────────────────────────────────────────
+CREATE TABLE audit_logs (
+    id            BIGSERIAL    PRIMARY KEY,
+    actor_user_id BIGINT,
+    action        VARCHAR(100) NOT NULL,
+    entity_type   VARCHAR(100),
+    entity_id     BIGINT,
+    detail        VARCHAR(1000),
+    created_at    TIMESTAMP    NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_audit_logs_actor_user_id ON audit_logs (actor_user_id);
+CREATE INDEX idx_audit_logs_created_at    ON audit_logs (created_at DESC);
+CREATE INDEX idx_audit_logs_entity        ON audit_logs (entity_type, entity_id);
+
+-- ── 초기 ADMIN 계정 ─────────────────────────────────────────
+-- password: admin1234  (BCrypt $2a$10$ 해시)
+-- 운영 배포 전 반드시 비밀번호를 변경하세요.
+INSERT INTO users (email, password, name, student_number, role, status, created_at, updated_at)
+VALUES (
+    'admin@cbnu.ac.kr',
+    '$2a$10$7EqJtq98hPqEX7fNZaFWoOwhFZ0.m/DM8DjKMGZ5r6j3Ky7.iy5mS',
+    '시스템 관리자',
+    NULL,
+    'ADMIN',
+    'ACTIVE',
+    NOW(),
+    NOW()
+);

--- a/backend/src/main/resources/db/migration/V2__add_vector_store.sql
+++ b/backend/src/main/resources/db/migration/V2__add_vector_store.sql
@@ -1,0 +1,23 @@
+-- ============================================================
+-- V2__add_vector_store.sql  :  pgvector 확장 및 벡터 저장소 테이블
+-- ============================================================
+-- 사전 조건: PostgreSQL 서버에 pgvector 확장이 설치되어 있어야 합니다.
+--   설치 명령: CREATE EXTENSION vector;  (슈퍼유저 권한 필요)
+-- ============================================================
+
+CREATE EXTENSION IF NOT EXISTS vector;
+
+-- 프로젝트 임베딩 벡터 저장 테이블
+-- dimension: 384  (sentence-transformers/all-MiniLM-L6-v2 기본값)
+-- AI 서비스 모델 변경 시 dimension을 맞춰 새 마이그레이션 작성 필요
+CREATE TABLE project_vectors (
+    project_id BIGINT  PRIMARY KEY REFERENCES projects (id) ON DELETE CASCADE,
+    embedding  vector(384)          NOT NULL,
+    metadata   JSONB
+);
+
+-- HNSW 인덱스 (코사인 유사도 기준, pgvector 0.5.0 이상 필요)
+-- 소규모 데이터셋에서는 인덱스 없이도 동작하므로 서버 버전 확인 후 적용
+CREATE INDEX idx_project_vectors_hnsw
+    ON project_vectors
+    USING hnsw (embedding vector_cosine_ops);


### PR DESCRIPTION
  ## 개요

  백엔드 운영 환경 배포를 위해 Mock으로만 존재하던 어댑터들을 실 구현체로 교체하고,
  개발/운영 환경을 Spring Profile로 분리했습니다.

  ---

  ## 변경 사항

  ### 1. Spring Profile 분리 (`application.yml` → `dev` / `prod`)

  | 항목 | dev | prod |
  |------|-----|------|
  | DB | H2 인메모리 | PostgreSQL (환경변수 주입) |
  | ddl-auto | create-drop | validate |
  | Flyway | 비활성 | 활성 |
  | 어댑터 | 전체 mock | 전체 실 구현 |

  - 민감값(`JWT_SECRET`, `DB_PASSWORD` 등)을 환경변수로 분리

  ---

  ### 2. Flyway 마이그레이션 스크립트 추가

  **V1__init.sql** — 초기 스키마 생성
  - `users`, `projects`, `project_tech_stack`, `project_files`, `audit_logs` 테이블
  - 조회 성능을 위한 인덱스 추가
  - 초기 ADMIN 계정 시드 데이터 포함

  **V2__add_vector_store.sql** — 벡터 저장소
  - pgvector 확장 활성화
  - `project_vectors` 테이블 (project_id, embedding vector(384), metadata JSONB)
  - HNSW 인덱스 (코사인 유사도 기반 ANN 검색)

  ---

  ### 3. 실 어댑터 구현 (총 4개)

  #### `AiServiceEmbeddingAdapter` — EmbeddingPort
  - AI 서비스 `POST /embed` 호출로 텍스트 임베딩 벡터 생성
  - 단건 / 배치 모두 지원
  - 연결 오류 시 빈 벡터 반환 (요청 전체 실패 방지)

  #### `S3FileStorageAdapter` — FileStoragePort
  - AWS SDK v2 (`software.amazon.awssdk:s3:2.27.0`) 사용
  - 업로드 / 다운로드 / 삭제 / Presigned URL 생성 구현
  - AWS 기본 자격증명 체인으로 인증 (코드에 키 하드코딩 없음)

  #### `PostgresProjectSearchAdapter` — ProjectSearchPort
  - JPA Specification (Criteria API) 기반 동적 쿼리
  - 키워드: title / summary / description / domain ILIKE 검색
  - 기술스택 필터: 지정한 스택을 **모두 포함**하는 프로젝트 (EXISTS 서브쿼리 AND 결합)
  - 연도 범위 / 학기 / 난이도 / 도메인 / 팀여부 필터 지원
  - Elasticsearch 등 별도 인프라 없이 기존 PostgreSQL 활용

  #### `PgVectorSearchAdapter` — VectorSearchPort
  - JdbcTemplate + 네이티브 SQL로 pgvector 직접 호출
  - `CAST(? AS vector)` 문법으로 별도 Java 라이브러리 없이 처리
  - upsert: `ON CONFLICT (project_id) DO UPDATE`
  - 유사도 검색: `<=>` 코사인 거리 연산자

  ---

  ## 환경변수 (운영 배포 시 필수)

  SPRING_PROFILES_ACTIVE=prod
  JWT_SECRET=<Base64 인코딩 키>
  AI_BASE_URL=http://<AI서비스 호스트>:8000
  DB_URL=jdbc:postgresql://<호스트>:5432/cbnu_archive
  DB_USERNAME=<계정>
  DB_PASSWORD=<비밀번호>
  S3_BUCKET=<버킷명>
  S3_REGION=ap-northeast-2
  AWS_ACCESS_KEY_ID=<액세스 키>
  AWS_SECRET_ACCESS_KEY=<시크릿 키>

  ## 인프라 사전 요구사항

  - PostgreSQL에 pgvector 확장 설치 (`postgresql-pgvector` 패키지 또는 `pgvector/pgvector:pg16` Docker 이미지)
  - AWS S3 버킷 생성 및 IAM 정책 설정 (`s3:PutObject`, `s3:GetObject`, `s3:DeleteObject`)

  ## 테스트

  - `./gradlew compileJava` 통과 확인
  - dev 프로파일: 기존 H2 + mock 동작 그대로 유지

  ---