### PR TITLE
[FEAT(backend)]: 서버 시작 시 기본 ADMIN 계정 자동 생성 (DataInitializer)

### DIFF
--- a/backend/src/main/java/com/ctrl/cbnu_archive/global/config/DataInitializer.java
+++ b/backend/src/main/java/com/ctrl/cbnu_archive/global/config/DataInitializer.java
@@ -1,0 +1,45 @@
+package com.ctrl.cbnu_archive.global.config;
+
+import com.ctrl.cbnu_archive.auth.domain.User;
+import com.ctrl.cbnu_archive.auth.domain.UserRole;
+import com.ctrl.cbnu_archive.auth.repository.UserRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Component;
+
+@Component
+public class DataInitializer implements CommandLineRunner {
+
+    private static final Logger log = LoggerFactory.getLogger(DataInitializer.class);
+
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    @Value("${app.admin.email}")
+    private String adminEmail;
+
+    @Value("${app.admin.password}")
+    private String adminPassword;
+
+    @Value("${app.admin.name}")
+    private String adminName;
+
+    public DataInitializer(UserRepository userRepository, PasswordEncoder passwordEncoder) {
+        this.userRepository = userRepository;
+        this.passwordEncoder = passwordEncoder;
+    }
+
+    @Override
+    public void run(String... args) {
+        if (userRepository.existsByEmail(adminEmail)) {
+            log.info("기본 관리자 계정이 이미 존재합니다: {}", adminEmail);
+            return;
+        }
+        User admin = User.create(adminEmail, passwordEncoder.encode(adminPassword), adminName, null, UserRole.ADMIN);
+        userRepository.save(admin);
+        log.info("기본 관리자 계정을 생성했습니다: {}", adminEmail);
+    }
+}

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -10,6 +10,10 @@ app:
       - http://localhost:5173
   ai:
     base-url: ${AI_BASE_URL:http://localhost:8000}
+  admin:
+    email: ${ADMIN_EMAIL:admin@cbnu.ac.kr}
+    password: ${ADMIN_PASSWORD:Admin1234!}
+    name: ${ADMIN_NAME:관리자}
 
 spring:
   servlet:


### PR DESCRIPTION
## 관련 이슈

<!--
"Closes #번호" 로 적으면 머지 시 이슈가 자동으로 닫힙니다.
이슈가 없으면 이 줄을 지워도 됩니다.
-->

Closes #58 

---
  ## Summary
  - `DataInitializer` 빈 추가 — 서버 시작 시 기본 관리자 계정이 없으면 자동 생성
  - `application.yml`에 `app.admin.*` 프로퍼티 분리, 환경 변수(`ADMIN_EMAIL`, `ADMIN_PASSWORD`, `ADMIN_NAME`)로
  오버라이드 가능
  - 이미 해당 이메일이 존재하면 스킵 (멱등)

  ## Background
  H2 인메모리 DB(`ddl-auto: create-drop`) 환경에서 서버 재시작 시마다 DB가 초기화되어
  `seed_projects.py` 등 로컬 개발 스크립트가 관리자 로그인 단계에서 실패하는 문제를 해결합니다.

  - `global/config/DataInitializer.java` 신규 추가
    - `CommandLineRunner` 구현, `UserRepository.existsByEmail()`로 중복 체크
    - `User.create(..., UserRole.ADMIN)` 사용 → status 자동 `ACTIVE`
    - BCrypt 해시 처리 후 저장
  - `application.yml`: `app.admin.email/password/name` 프로퍼티 추가

  ## Default Credentials (로컬 전용)
  | 항목 | 값 |
  |------|-----|
  | email | `admin@cbnu.ac.kr` |
  | password | `Admin1234!` |
  
  > 운영 환경에서는 환경 변수로 반드시 교체하거나 `DataInitializer`를 비활성화하세요.